### PR TITLE
November 2018 updates

### DIFF
--- a/css/activities.css
+++ b/css/activities.css
@@ -2786,6 +2786,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4458,7 +4497,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5374,11 +5413,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5579,7 +5627,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6537,39 +6585,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6715,7 +6773,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6935,7 +6993,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6977,7 +7035,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7065,7 +7123,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7239,7 +7297,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7597,7 +7655,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8761,7 +8819,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   border: 1px solid #d8d8d8 !important; }
   body > div[id*="dialogs_deleteConfirm"] * {
     max-width: 100% !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusDialog.lotusForm2._lotusDelete {
     border: none !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusErrorContent {
@@ -9563,11 +9621,11 @@ body.scloud3 .lotusHeader #actViewLabel h1 {
 .lotusui30 #activitiesBanner + #lotusPlaceBar.lotusPlaceBar {
   padding-left: 48px;
   margin-left: 240px;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   width: calc(100% - 240px); }
   .lotusui30 #activitiesBanner + #lotusPlaceBar.lotusPlaceBar > .lotusRightCorner {
     padding: 0 !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     min-width: 0 !important; }
     .lotusui30 #activitiesBanner + #lotusPlaceBar.lotusPlaceBar > .lotusRightCorner > .lotusInner:after {
       content: '';
@@ -9653,7 +9711,7 @@ div[id^="widget_lconn_act_ToDoForm_"][id$="duedate"] {
   position: relative !important;
   top: -15px !important;
   margin-left: 0px !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .lotusui.lotusui30dojo.lotusui30_body .lotusFrame.activities .lotusMain .lotusColLeft .lotusMenu,
   .lotusui.lotusui30dojo.lotusui30_body .lotusFrame.activities .lotusMain #activitypage .lotusMenu,
   .lotusui.lotusui30dojo.lotusui30_body .lotusFrame.activities .lotusMain #recentupdatesid .lotusMenu {
@@ -9751,7 +9809,7 @@ div[id^="widget_lconn_act_ToDoForm_"][id$="duedate"] {
       .lotusui.lotusui30dojo.lotusui30_body .lotusFrame.activities .lotusMain #recentupdatesid .lotusMenu .lotusBottomCorner:not(:first-child) div[dojoattachpoint="newSectionLink_AP"] a {
         font-size: 14px !important;
         font-weight: 600 !important;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         margin: 0px 0px !important;
         padding: 14px 24px !important;
         padding-left: calc(15px + 24px) !important; }

--- a/css/blogs.css
+++ b/css/blogs.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8762,7 +8820,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   border: 1px solid #d8d8d8 !important; }
   body > div[id*="dialogs_deleteConfirm"] * {
     max-width: 100% !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusDialog.lotusForm2._lotusDelete {
     border: none !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusErrorContent {
@@ -8921,7 +8979,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       font-weight: normal !important;
       font-size: 0.875rem;
       width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -9989,7 +10047,7 @@ body > div[id*="dialogs_deleteConfirm"] {
         position: absolute;
         top: 0;
         left: 0;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 100%; }
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > .lotusMenuSubsection ul li.lotusSelected a,
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > div ul li.lotusSelected a,
@@ -10212,7 +10270,7 @@ body > div[id*="dialogs_deleteConfirm"] {
     transition: none !important;
     font-weight: normal !important;
     font-size: 0.875rem;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     overflow: visible;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -10267,7 +10325,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       .lotusColLeft div[id^="lconn_share_widget_Tree_"] .headerSelector.lotusSelected::before {
         content: '';
         display: block;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 4px;
         height: calc( (14px * 2) + calc(14px * 1.5) );
         position: absolute;
@@ -10310,7 +10368,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: calc(100% - 40px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .lotusMain #lotusColLeft #mainActions {
   padding: 14px 24px;
@@ -11274,6 +11332,9 @@ fieldset.blogsHiddenBorder > input {
 fieldset.blogsHiddenBorder {
   margin-left: 0;
   padding-left: 0; }
+
+.lconnInsertImage input.blogImgLayout.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 form[name="rollerConfigForm"] .formtableNoDesc td.field, form[name="rollerConfigForm"] .formtableNoDesc td.label {
   border: none;

--- a/css/communities.css
+++ b/css/communities.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8641,7 +8699,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   border: 1px solid #d8d8d8 !important; }
   body > div[id*="dialogs_deleteConfirm"] * {
     max-width: 100% !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusDialog.lotusForm2._lotusDelete {
     border: none !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusErrorContent {
@@ -8800,7 +8858,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       font-weight: normal !important;
       font-size: 0.875rem;
       width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -9868,7 +9926,7 @@ body > div[id*="dialogs_deleteConfirm"] {
         position: absolute;
         top: 0;
         left: 0;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 100%; }
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > .lotusMenuSubsection ul li.lotusSelected a,
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > div ul li.lotusSelected a,
@@ -10091,7 +10149,7 @@ body > div[id*="dialogs_deleteConfirm"] {
     transition: none !important;
     font-weight: normal !important;
     font-size: 0.875rem;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     overflow: visible;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -10146,7 +10204,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       .lotusColLeft div[id^="lconn_share_widget_Tree_"] .headerSelector.lotusSelected::before {
         content: '';
         display: block;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 4px;
         height: calc( (14px * 2) + calc(14px * 1.5) );
         position: absolute;
@@ -10189,7 +10247,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: calc(100% - 40px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .lotusMain #lotusColLeft #mainActions {
   padding: 14px 24px;
@@ -12610,7 +12668,8 @@ div[id^="lconn_core_TempTabbedDialog_"] .dijitContentPane, div[id^="lconn_core_T
 html.lconnFiles.files-enable-recent-view .lotusTopNav #lotusToolBar .toolActions,
 html.lconnFiles.files-enable-refine-panel .lotusTopNav #lotusToolBar .toolActions,
 html.lconnFiles.files-enable-simplify-left-nav .lotusTopNav #lotusToolBar .toolActions {
-  width: 182px; }
+  width: 182px;
+  box-sizing: content-box !important; }
   html.lconnFiles.files-enable-recent-view .lotusTopNav #lotusToolBar .toolActions .actionOn:after,
   html.lconnFiles.files-enable-refine-panel .lotusTopNav #lotusToolBar .toolActions .actionOn:after,
   html.lconnFiles.files-enable-simplify-left-nav .lotusTopNav #lotusToolBar .toolActions .actionOn:after {
@@ -12764,7 +12823,8 @@ tr.lotusSort td.lotusFirstCell {
 div.filesListFilled #scene-body tr:not(.hentry) td.lotusFirstCell {
   top: 0 !important; }
   div.filesListFilled #scene-body tr:not(.hentry) td.lotusFirstCell .lotusCheckbox {
-    padding-top: 6px; }
+    padding-top: 6px;
+    margin-top: 2px; }
 div.filesListFilled #scene-body tr.hentry td.lotusFirstCell input {
   margin: 0 !important; }
 

--- a/css/files.css
+++ b/css/files.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8434,6 +8492,8 @@ html.lconnFiles.files-enable-simplify-left-nav .lotusMain #lotusColLeft .lotusMe
     padding-left: calc(24px - 4px) !important;
     border-left: 4px solid #3C6DF0 !important;
     transition: border 0.23s ease, padding 0.23s ease; }
+html.lconnFiles.files-enable-simplify-left-nav .lotusMain #lotusColLeft .myDriveNavigation .lotusInner {
+  box-sizing: content-box; }
 html.lconnFiles.files-enable-simplify-left-nav .lotusMain #lotusColLeft #menu_myfolders_childContainer {
   margin-left: 32px !important;
   padding-right: 24px; }
@@ -8626,7 +8686,7 @@ html.lconnFiles.files-enable-simplify-left-nav .lotusMain #lotusColLeft .myDrive
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100% !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   float: none !important; }
 
 .lconnFiles .lotusTopNav .lotusTitleBar .lotusColLeft.newButton,
@@ -8682,7 +8742,8 @@ html.lconnFiles.files-enable-simplify-left-nav .lotusMain #lotusColLeft .myDrive
 html.lconnFiles.files-enable-recent-view .lotusTopNav #lotusToolBar .toolActions,
 html.lconnFiles.files-enable-refine-panel .lotusTopNav #lotusToolBar .toolActions,
 html.lconnFiles.files-enable-simplify-left-nav .lotusTopNav #lotusToolBar .toolActions {
-  width: 182px; }
+  width: 182px;
+  box-sizing: content-box !important; }
   html.lconnFiles.files-enable-recent-view .lotusTopNav #lotusToolBar .toolActions .actionOn:after,
   html.lconnFiles.files-enable-refine-panel .lotusTopNav #lotusToolBar .toolActions .actionOn:after,
   html.lconnFiles.files-enable-simplify-left-nav .lotusTopNav #lotusToolBar .toolActions .actionOn:after {
@@ -8836,7 +8897,8 @@ tr.lotusSort td.lotusFirstCell {
 div.filesListFilled #scene-body tr:not(.hentry) td.lotusFirstCell {
   top: 0 !important; }
   div.filesListFilled #scene-body tr:not(.hentry) td.lotusFirstCell .lotusCheckbox {
-    padding-top: 6px; }
+    padding-top: 6px;
+    margin-top: 2px; }
 div.filesListFilled #scene-body tr.hentry td.lotusFirstCell input {
   margin: 0 !important; }
 

--- a/css/forums.css
+++ b/css/forums.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8613,7 +8671,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   border: 1px solid #d8d8d8 !important; }
   body > div[id*="dialogs_deleteConfirm"] * {
     max-width: 100% !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusDialog.lotusForm2._lotusDelete {
     border: none !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusErrorContent {
@@ -8772,7 +8830,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       font-weight: normal !important;
       font-size: 0.875rem;
       width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -9840,7 +9898,7 @@ body > div[id*="dialogs_deleteConfirm"] {
         position: absolute;
         top: 0;
         left: 0;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 100%; }
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > .lotusMenuSubsection ul li.lotusSelected a,
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > div ul li.lotusSelected a,
@@ -10063,7 +10121,7 @@ body > div[id*="dialogs_deleteConfirm"] {
     transition: none !important;
     font-weight: normal !important;
     font-size: 0.875rem;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     overflow: visible;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -10118,7 +10176,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       .lotusColLeft div[id^="lconn_share_widget_Tree_"] .headerSelector.lotusSelected::before {
         content: '';
         display: block;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 4px;
         height: calc( (14px * 2) + calc(14px * 1.5) );
         position: absolute;
@@ -10161,7 +10219,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: calc(100% - 40px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .lotusMain #lotusColLeft #mainActions {
   padding: 14px 24px;

--- a/css/global.css
+++ b/css/global.css
@@ -2865,6 +2865,44 @@ they should be display: block; */ }
     padding: 0.25rem 0.25rem 0.125rem 0.25rem !important; }
     .ics-viewer #activityStream a.lotusDelete img:focus {
       outline: 1px solid #3C6DF0 !important; }
+  .ics-viewer #sametime-tray ul.navsimplelist button {
+    border-radius: 2rem !important;
+    border-width: 1px !important;
+    border-style: solid !important;
+    box-shadow: none !important;
+    transform: translateZ(0) !important;
+    -webkit-font-smoothing: antialiased !important;
+    cursor: pointer !important;
+    -webkit-box-align: center !important;
+    -webkit-box-pack: center !important;
+    text-align: center !important;
+    transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+    white-space: nowrap !important;
+    padding: 9px 20px !important;
+    background-image: none !important;
+    margin: 2px 4px 3px 2px !important;
+    background-color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important;
+    color: #FFFFFF !important;
+    font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+    padding: 0 20px !important;
+    margin-top: 12px !important; }
+    .ics-viewer #sametime-tray ul.navsimplelist button, .ics-viewer #sametime-tray ul.navsimplelist button:hover, .ics-viewer #sametime-tray ul.navsimplelist button:active, .ics-viewer #sametime-tray ul.navsimplelist button:focus {
+      text-decoration: none !important;
+      font-weight: 500 !important; }
+    .ics-viewer #sametime-tray ul.navsimplelist button:hover, .ics-viewer #sametime-tray ul.navsimplelist button:active {
+      outline: none; }
+    .ics-viewer #sametime-tray ul.navsimplelist button:focus {
+      box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+      outline: none !important; }
+    .dj_a11y .ics-viewer #sametime-tray ul.navsimplelist button:focus, .dijit_a11y .ics-viewer #sametime-tray ul.navsimplelist button:focus {
+      box-shadow: none !important;
+      outline: 1px solid #3C6DF0 !important;
+      outline-offset: 1px; }
+    .ics-viewer #sametime-tray ul.navsimplelist button:active, .ics-viewer #sametime-tray ul.navsimplelist button:hover {
+      background-color: #FFFFFF !important;
+      color: #3C6DF0 !important;
+      border-color: #3C6DF0 !important; }
   .ics-viewer input[type=checkbox] {
     height: 16px !important;
     width: 20px !important;
@@ -4479,7 +4517,7 @@ they should be display: block; */ }
       .ics-viewer .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
         border-bottom: 1px solid #d8d8d8 !important;
         padding: .75rem 2.75rem .75rem 0 !important;
-        box-sizing: border-box; }
+        box-sizing: border-box !important; }
         .ics-viewer .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
           border-color: #3C6DF0 !important;
           box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5329,11 +5367,18 @@ they should be display: block; */ }
   .ics-viewer .lotusDialogBorder > .lotusDialog > div:not(.lotusTabContainer) {
     padding-right: 2rem !important;
     padding-left: 2rem !important; }
+  .ics-viewer .lconnInsertImage.forum .lotusDialogHeader,
+  .ics-viewer #blogImgTabDlg .lotusDialogHeader,
+  .ics-viewer #blogsImageTabDiv .lotusDialogHeader {
+    padding-top: 32px !important; }
   .ics-viewer .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
     padding-left: 2rem !important;
     padding-top: 1rem !important; }
     .ics-viewer .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
       padding-left: 2rem !important; }
+  .ics-viewer .images .uploadedImageTd.imageSelected .insertImage,
+  .ics-viewer .lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+    border: 2px solid #3C6DF0 !important; }
   .ics-viewer input.moveCheckBox {
     vertical-align: middle !important; }
     .ics-viewer input.moveCheckBox label {
@@ -5505,7 +5550,7 @@ they should be display: block; */ }
   .ics-viewer .sc .dialogImportList {
     padding-right: 3rem !important;
     padding-left: 3rem !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     .ics-viewer .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
       margin: 0 !important; }
   .ics-viewer .sc .slideDialog,
@@ -6432,39 +6477,49 @@ they should be display: block; */ }
               left: -1px;
               width: calc(100% + 2px);
               height: 0; }
-  .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+  .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+  .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top {
     border-bottom: 1px solid #d8d8d8 !important;
     width: auto !important;
     padding: 0 !important; }
-    .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+    .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+    .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
       padding-bottom: calc(.375rem + 3px) !important; }
-      .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+      .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+      .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
         font-size: 14px !important;
         font-weight: 600 !important;
         margin-left: 1rem !important;
         background-image: none !important;
         border-radius: 2px;
         color: #595859 !important; }
-        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+        .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
           margin-left: .5rem !important; }
-        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+        .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
           position: relative;
           color: #000000 !important; }
-        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+        .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
           color: #FFFFFF !important;
           background-color: #3C6DF0 !important;
           border-color: #3C6DF0 !important; }
-        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+        .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
           color: #595859 !important;
           background-color: transparent !important;
           border-color: #3C6DF0 !important; }
-        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+        .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+        .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
           color: inherit !important;
           border: none !important;
           text-transform: none !important; }
-          .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+          .ics-viewer div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+          .ics-viewer div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
             outline: 0 !important; }
-  .ics-viewer div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+  .ics-viewer div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+  .ics-viewer div.question-creator .dijitTabContainer .lotusDialogFooter {
     padding: 1rem 1rem !important; }
   .ics-viewer ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
     min-width: 1px !important;
@@ -6599,7 +6654,7 @@ they should be display: block; */ }
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   .ics-viewer #socialTags #tagsYouAddedView .lotusTags span.lotusRight, .ics-viewer #socialTags #tagsList .lotusTags span.lotusRight {
     order: 2; }
     .ics-viewer #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, .ics-viewer #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6816,7 +6871,7 @@ they should be display: block; */ }
       left: auto !important;
       padding-right: .5rem !important;
       max-width: calc(100% - 58px) !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
     .ics-viewer #lconnTagWidget_tagList > li .lotusRight,
     .ics-viewer #lconnTagWidget_tagCloudView > li .lotusRight,
     .ics-viewer ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6857,7 +6912,7 @@ they should be display: block; */ }
     overflow: hidden;
     text-overflow: ellipsis;
     background: #FFFFFF !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     .ics-viewer ul.lotusRelatedTags a a {
       color: #000000 !important;
       font-weight: normal !important; }
@@ -6944,7 +6999,7 @@ they should be display: block; */ }
       left: auto !important;
       padding-right: .5rem !important;
       max-width: calc(100% - 58px) !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .ics-viewer div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
       .ics-viewer div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
         color: #000000 !important;
@@ -7109,7 +7164,7 @@ they should be display: block; */ }
       height: 100%;
       margin: 0 3px;
       padding: .45rem 0;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       display: inline-block;
       vertical-align: middle; }
       .ics-viewer .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7459,7 +7514,7 @@ they should be display: block; */ }
     padding-right: 1.5rem !important;
     float: left;
     margin-bottom: .5rem !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     position: relative; }
     .ics-viewer #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
     .ics-viewer #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, .ics-viewer #addMembersWidget #memberList .member a,
@@ -8693,7 +8748,7 @@ img[class*="Calendar"],
   width: 16px;
   height: 16px;
   padding: 16px 16px 0 0;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .ics-viewer-title .lconn-ftype16, .ics-viewer-title .iconsFileTypes16 {
   background-size: 24px 24px !important;
@@ -8719,7 +8774,7 @@ img[class*="Calendar"],
   width: 32px;
   height: 32px;
   padding-left: 32px;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   background-repeat: no-repeat; }
 
 .lconn-ftype64, .iconsFileTypes64 {
@@ -8733,7 +8788,7 @@ img[class*="Calendar"],
   width: 32px;
   height: 32px;
   padding: 32px 32px 0 0;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .lconn-ftype16-docx,
 .lconn-ftype16-xlsx,
@@ -8743,7 +8798,7 @@ img[class*="Calendar"],
   width: 16px;
   height: 16px;
   padding: 16px 16px 0 0;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 img[class*="ftype"],
 img[class*="Default"] {
@@ -8904,7 +8959,7 @@ img[class$="json"],
 img[class$="scss"],
 img[class$="xml"],
 img[class*="Code"],
-span[class$="css"],
+span[class$="css"]:not(.freedom-base-mixin-css),
 span[class$="dmg"],
 span[class$="exe"],
 span[class$="html"]:not(.cke_dialog_ui_html),
@@ -9025,7 +9080,7 @@ span[class*="Calendar"]:not([class*="dijitCalendar"]) {
   width: 100%;
   position: fixed;
   top: 0px;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   html.catalog-ui-updated .catalog .ics-scbanner:not(.isfixed) {
     position: absolute;
     top: -40px; }
@@ -9211,7 +9266,7 @@ body.meetingBody:not(.cke_editable),
 .lotusui30 .lotusFooter,
 #lotusFrame #lotusFooter.lotusFooter,
 .lotusFrame #lotusFooter.lotusFooter {
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   margin-left: 0 !important;
   margin-right: 0 !important;
   max-width: 100%; }
@@ -9229,7 +9284,7 @@ body.meetingBody:not(.cke_editable),
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout #lotusMain[role="tabpanel"],
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout #lotusMain[role="tabpanel"] {
     padding-left: 40px !important;
-    box-sizing: border-box; } }
+    box-sizing: border-box !important; } }
 @media screen and (max-width: 1060px) {
   .lotusui30 .lotusBanner .lotusInner,
   .lotusui30 .lotusBannerExt .lotusWrapper,
@@ -9252,11 +9307,11 @@ body.meetingBody:not(.cke_editable),
   #lotusMain #lotusContent.wpthemeWide {
     width: 100% !important;
     min-width: 100% !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lotusMain #lotusColLeft ~ #lotusContent.wpthemeWide {
     width: calc(100% - 240px) !important;
     min-width: calc(100% - 240px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lotusMain #lotusColLeft ~ .lotusColRight:not([style^="display: none;"]) ~ #lotusContent.wpthemeWide {
     width: calc(100% - 475px) !important;
     min-width: calc(100% - 475px) !important; }
@@ -9266,25 +9321,25 @@ body.meetingBody:not(.cke_editable),
   body #lotusMain .lotusColRight {
     width: 200px !important;
     min-width: 200px !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   body #lotusMain + #lotusContent {
     width: calc(100% - 488px) !important;
     min-width: calc(100% - 488px) !important;
     float: right;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
 
   #profileBody,
   .activityStreamPage #lotusContent {
     width: calc(100% - 505px) !important;
     min-width: calc(100% - 505px) !important;
     float: right;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
 
   #profilePaneRight,
   .activityStreamPage #lotusColRight {
     width: 150px !important;
     min-width: 150px !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     margin-left: 2.45rem !important; }
     #profilePaneRight #recent-friends-container .lotusChunk .lotusNetworkPerson,
     .activityStreamPage #lotusColRight #recent-friends-container .lotusChunk .lotusNetworkPerson {
@@ -9304,7 +9359,7 @@ body.meetingBody:not(.cke_editable),
       width: 50% !important; }
     .verseTheme .stmeetingCenter #joinUrl {
       width: 100% !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
     .verseTheme .stmeetingCenter .verseColsRight {
       margin-left: 5% !important; }
 
@@ -9324,7 +9379,7 @@ body.meetingBody:not(.cke_editable),
   .lotusColLeft.wpthemeThin ~ #lotusMainColumns {
     margin-left: 240px !important; }
     .lotusColLeft.wpthemeThin ~ #lotusMainColumns #lotusContent {
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
 
   .lotusWidget_3columnLayoutWithBanner .lotusColLeft.wpthemeThin ~ #lotusMainColumns #lotusColBanner,
   .lotusWidget_3columnLayoutWithBanner .lotusColLeft.wpthemeThin ~ #lotusMainColumns #lotusColRight,
@@ -9345,7 +9400,7 @@ body.meetingBody:not(.cke_editable),
     width: 250px !important; } }
 @media (max-width: 899px) {
   #lotusMain {
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
 
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout #lotusColLeft.wpthemeNarrow,
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout #lotusColBanner ~ #lotusColLeft.wpthemeNarrow,
@@ -9392,7 +9447,7 @@ body.meetingBody:not(.cke_editable),
     max-width: calc(50% - 15px);
     vertical-align: top;
     display: inline-block !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
 
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout #lotusMainColumns {
     float: right !important;
@@ -9401,7 +9456,7 @@ body.meetingBody:not(.cke_editable),
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout #lotusColRight.lotusColRight.wpthemeNarrow.wpthemeNarrowPlus {
     width: 100% !important;
     max-width: 100%;
-    box-sizing: border-box; } }
+    box-sizing: border-box !important; } }
 @media (min-width: 1271px) {
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout #lotusColLeft.wpthemeNarrow,
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout #lotusColBanner ~ #lotusColLeft.wpthemeNarrow,
@@ -9417,7 +9472,7 @@ body.meetingBody:not(.cke_editable),
     max-width: calc(33% - 15px);
     vertical-align: top;
     display: inline-block !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
 
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout #lotusMainColumns {
     width: calc(66% - 17px) !important; }
@@ -9425,7 +9480,7 @@ body.meetingBody:not(.cke_editable),
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout #lotusColRight.lotusColRight.wpthemeNarrow.wpthemeNarrowPlus {
     width: calc(50% - 16px) !important;
     max-width: calc(50% - 16px);
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
 
   .lotusWidget_3columnsTopMenuLayout #contentArea,
   .lotusWidget_3columnsWithBannerTopMenuLayout #contentArea {
@@ -9464,9 +9519,23 @@ div[id^="lconn_communities_catalog_widgets_ResultsDisplayWidget_"], div[id^="lco
 .lotusui30_layout .activityStreamPage.lotusMain .lotusColLeft:after {
   border-right-width: 264px !important; }
 
-#lotusFrame .tabNavBar:not(.tabNavFixed) .icSearchPaneButton {
+.lotusui30_body.scloud3.tundra:not(.compactMode):not(.concord) {
+  min-width: 0 !important; }
+
+#lotusFrame #lotusTitleBar .lotusInner div.icSearchPaneButton,
+#lotusFrame .lotusTitleBar2 .lotusInner div.icSearchPaneButton,
+.lotusFrame #lotusTitleBar .lotusInner div.icSearchPaneButton,
+.lotusFrame .lotusTitleBar .lotusInner div.icSearchPaneButton {
   top: calc(40px + 20px) !important; }
-#lotusFrame .tabNavBar.tabNavFixed .icSearchPaneButton {
+#lotusFrame #lotusTitleBar .tabNavBar:not(.tabNavFixed) .icSearchPaneButton,
+#lotusFrame .lotusTitleBar2 .tabNavBar:not(.tabNavFixed) .icSearchPaneButton,
+.lotusFrame #lotusTitleBar .tabNavBar:not(.tabNavFixed) .icSearchPaneButton,
+.lotusFrame .lotusTitleBar .tabNavBar:not(.tabNavFixed) .icSearchPaneButton {
+  top: calc(40px + 20px) !important; }
+#lotusFrame #lotusTitleBar .tabNavBar.tabNavFixed .icSearchPaneButton,
+#lotusFrame .lotusTitleBar2 .tabNavBar.tabNavFixed .icSearchPaneButton,
+.lotusFrame #lotusTitleBar .tabNavBar.tabNavFixed .icSearchPaneButton,
+.lotusFrame .lotusTitleBar .tabNavBar.tabNavFixed .icSearchPaneButton {
   top: 20px !important; }
 
 .icSearchPaneButton {
@@ -9501,6 +9570,13 @@ div[id^="lconn_communities_catalog_widgets_ResultsDisplayWidget_"], div[id^="lco
       top: -20px !important; }
     .icSearchPaneButton.icSearchBarMode .icSearchBar {
       padding-top: 0px !important; }
+
+.icSearchPane,
+.icSearchPane * {
+  box-sizing: border-box !important; }
+
+.icSearchPane {
+  top: calc(40px + 1px) !important; }
 
 .icSearchBar a.icSearchIcon {
   width: 16px !important;
@@ -9543,5 +9619,489 @@ div[id^="lconn_communities_catalog_widgets_ResultsDisplayWidget_"], div[id^="lco
   height: 0;
   width: 100%;
   clear: both; }
+
+body.lotusui30_body .uploadFileGadgetDiv {
+  width: 500px !important; }
+  body.lotusui30_body .uploadFileGadgetDiv fieldset[id="lconn_files_widget_UploadFile_0_share_with_fieldset"] {
+    min-width: 380px !important; }
+
+body.lconnShareboxGadget {
+  min-width: 500px !important;
+  max-width: 100%; }
+
+.lotusui30dojo .lcSharebox div.dijitDialogTitleBar,
+.lcSharebox .dijitTabContainer {
+  padding-right: 2rem !important;
+  padding-left: 2rem !important;
+  margin-left: 0 !important; }
+
+.lotusui30dojo .lcSharebox div.dijitDialogTitleBar {
+  box-shadow: none !important; }
+
+.lotusDialogHeader.shareBoxBottomHeader {
+  padding-top: 0 !important; }
+
+body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"],
+body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important; }
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled {
+    border-radius: 2rem !important;
+    border-width: 1px !important;
+    border-style: solid !important;
+    box-shadow: none !important;
+    transform: translateZ(0) !important;
+    -webkit-font-smoothing: antialiased !important;
+    cursor: pointer !important;
+    -webkit-box-align: center !important;
+    -webkit-box-pack: center !important;
+    text-align: center !important;
+    transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+    white-space: nowrap !important;
+    padding: 9px 20px !important;
+    background-image: none !important;
+    margin: 2px 4px 3px 2px !important;
+    background-color: #FFFFFF !important;
+    border-color: #3C6DF0 !important;
+    color: #3C6DF0 !important; }
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:hover, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:active, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:focus,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:hover,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:active,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:focus {
+      text-decoration: none !important;
+      font-weight: 500 !important; }
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:hover, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:active,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:hover,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:active {
+      outline: none; }
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:focus,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:focus {
+      box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+      outline: none !important; }
+    .dj_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:focus, .dijit_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:focus,
+    .dj_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:focus,
+    .dijit_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:focus {
+      box-shadow: none !important;
+      outline: 1px solid #3C6DF0 !important;
+      outline-offset: 1px; }
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:active, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"].lotusBtnDisabled:hover,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:active,
+    body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"].lotusBtnDisabled:hover {
+      background-color: #3C6DF0 !important;
+      color: #FFFFFF !important;
+      border-color: #3C6DF0 !important; }
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"], body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:hover, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:active, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:focus,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"],
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:hover,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:active,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:hover, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:active,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:hover,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:active {
+    outline: none; }
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:focus,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:focus, .dijit_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:focus,
+  .dj_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:focus,
+  .dijit_a11y body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:active, body.lconnShareboxGadget input[type="button"][dojoattachpoint="postButtonNode"]:hover,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:active,
+  body.lconnShareboxGadget input[type="button"][dojoattachpoint="resetButtonNode"]:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+body.lconnShareboxGadget select {
+  font-size: 12.8px !important;
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  display: block !important;
+  width: auto !important;
+  min-width: 50% !important;
+  max-width: 100% !important;
+  padding: 0 2.75rem 0.75rem 0 !important;
+  color: #000000 !important;
+  background-color: transparent !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  border-radius: 0 !important;
+  cursor: pointer !important;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 version=%221.1%22 x=%220px%22 y=%220px%22 viewBox=%220 0 12 7.5%22%3E%3Cpath fill=%22%23595859%22 d=%22M10.6,0L6,4.7L1.4,0L0,1.4l6,6.1l6-6.1L10.6,0z%22/%3E%3C/svg%3E") !important;
+  background-size: 0.75rem !important;
+  background-position: right .4rem !important;
+  background-repeat: no-repeat !important;
+  height: auto !important;
+  min-width: 45% !important; }
+  body.lconnShareboxGadget select:focus {
+    border-bottom: 2px solid #3C6DF0 !important;
+    outline: none !important; }
+  body.lconnShareboxGadget select[disabled] {
+    cursor: not-allowed !important;
+    color: #969696 !important; }
+body.lconnShareboxGadget input[type="text"],
+body.lconnShareboxGadget input.lotusText {
+  line-height: 1.5 !important;
+  padding: 0 !important;
+  background: none !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  font-size: 12.8px !important;
+  padding-right: 1rem !important;
+  padding-bottom: .375rem !important;
+  box-sizing: border-box !important;
+  height: auto !important;
+  padding-top: .375rem !important; }
+  body.lconnShareboxGadget input[type="text"]:focus, body.lconnShareboxGadget input[type="text"] .dijitTextBoxFocused,
+  body.lconnShareboxGadget input.lotusText:focus,
+  body.lconnShareboxGadget input.lotusText .dijitTextBoxFocused {
+    outline: none !important;
+    border-color: #3C6DF0 !important;
+    box-shadow: 0 1px 0 #3C6DF0 !important; }
+body.lconnShareboxGadget div[role="search"] {
+  border: none !important; }
+body.lconnShareboxGadget li.lotusFirst a {
+  outline: none !important; }
+body.lconnShareboxGadget button[id="lconn_btn_browse_files"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important; }
+  body.lconnShareboxGadget button[id="lconn_btn_browse_files"], body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:hover, body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:active, body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:hover, body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:active {
+    outline: none; }
+  body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:focus, .dijit_a11y body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:active, body.lconnShareboxGadget button[id="lconn_btn_browse_files"]:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+body.lconnShareboxGadget input[type="submit"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important; }
+  body.lconnShareboxGadget input[type="submit"], body.lconnShareboxGadget input[type="submit"]:hover, body.lconnShareboxGadget input[type="submit"]:active, body.lconnShareboxGadget input[type="submit"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  body.lconnShareboxGadget input[type="submit"]:hover, body.lconnShareboxGadget input[type="submit"]:active {
+    outline: none; }
+  body.lconnShareboxGadget input[type="submit"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y body.lconnShareboxGadget input[type="submit"]:focus, .dijit_a11y body.lconnShareboxGadget input[type="submit"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  body.lconnShareboxGadget input[type="submit"]:active, body.lconnShareboxGadget input[type="submit"]:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+  body.lconnShareboxGadget input[type="submit"].lotusBtnDisabled, body.lconnShareboxGadget input[type="submit"].lotusBtnDisabled:hover, body.lconnShareboxGadget input[type="submit"].lotusBtnDisabled:active {
+    cursor: not-allowed !important;
+    background-color: #969696 !important;
+    color: #FFFFFF !important;
+    border-color: #969696 !important; }
+  body.lconnShareboxGadget input[type="submit"].lotusBtnDisabled:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #969696 !important; }
+  .dj_a11y body.lconnShareboxGadget input[type="submit"].lotusBtnDisabled:focus, .dijit_a11y body.lconnShareboxGadget input[type="submit"].lotusBtnDisabled:focus {
+    box-shadow: none !important;
+    outline: 1px solid #FFFFFF !important;
+    outline-offset: 1px; }
+body.lconnShareboxGadget input[value="Cancel"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #FFFFFF !important;
+  border-color: #3C6DF0 !important;
+  color: #3C6DF0 !important; }
+  body.lconnShareboxGadget input[value="Cancel"], body.lconnShareboxGadget input[value="Cancel"]:hover, body.lconnShareboxGadget input[value="Cancel"]:active, body.lconnShareboxGadget input[value="Cancel"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  body.lconnShareboxGadget input[value="Cancel"]:hover, body.lconnShareboxGadget input[value="Cancel"]:active {
+    outline: none; }
+  body.lconnShareboxGadget input[value="Cancel"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y body.lconnShareboxGadget input[value="Cancel"]:focus, .dijit_a11y body.lconnShareboxGadget input[value="Cancel"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  body.lconnShareboxGadget input[value="Cancel"]:active, body.lconnShareboxGadget input[value="Cancel"]:hover {
+    background-color: #3C6DF0 !important;
+    color: #FFFFFF !important;
+    border-color: #3C6DF0 !important; }
+body.lconnShareboxGadget .lotusDialogHeader {
+  background-color: #FFFFFF !important;
+  color: #000000 !important; }
+  body.lconnShareboxGadget .lotusDialogHeader h1 {
+    color: #000000 !important;
+    font-weight: 500 !important;
+    font-size: 1.3125rem !important; }
+body.lconnShareboxGadget .lotusDialogClose img {
+  display: none !important; }
+body.lconnShareboxGadget .lotusDialogClose {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg width=%2224px%22 height=%2224px%22 viewBox=%220 0 24 24%22 version=%221.1%22 xmlns=%22http://www.w3.org/2000/svg%22 xmlns:xlink=%22http://www.w3.org/1999/xlink%22%3E%3Cg id=%22Icons-24-x-24px%22 stroke=%22none%22 stroke-width=%221%22 fill=%22none%22 fill-rule=%22evenodd%22%3E%3Cg id=%22close_24%22 fill=%22%23595859%22%3E%3Cpolygon id=%22close%22 points=%2218 6 12.353 11.647 6.708 6 6 6.707 11.647 12.354 6 18 6.708 18.707 12.353 13.061 18 18.707 18.707 18 13.061 12.354 18.707 6.707%22%3E%3C/polygon%3E%3C/g%3E%3C/g%3E%3C/svg%3E") !important;
+  background-position-x: center !important;
+  background-position-y: center !important;
+  height: 24px !important;
+  width: 24px !important;
+  top: 1rem !important;
+  right: 1rem !important;
+  padding: 0.25rem 0.25rem 0.125rem 0.25rem !important; }
+  body.lconnShareboxGadget .lotusDialogClose:focus {
+    outline: 1px solid #3C6DF0 !important; }
+body.lconnShareboxGadget div[role="tablist"] {
+  padding-bottom: calc(.375rem + 3px) !important; }
+body.lconnShareboxGadget .dijitTabInner.dijitTabContent,
+body.lconnShareboxGadget .lconnPickerSourceToCheck .lconnPickerSourceLabel {
+  position: relative;
+  padding: 8px 16px 4px 32px !important;
+  margin: 0 !important;
+  color: #595859 !important;
+  border-radius: 2px !important;
+  border: 1px solid transparent !important;
+  width: auto !important; }
+  body.lconnShareboxGadget .dijitTabInner.dijitTabContent .lconnPickerSourceLabelSpan,
+  body.lconnShareboxGadget .lconnPickerSourceToCheck .lconnPickerSourceLabel .lconnPickerSourceLabelSpan {
+    color: inherit !important; }
+  body.lconnShareboxGadget .dijitTabInner.dijitTabContent:hover,
+  body.lconnShareboxGadget .lconnPickerSourceToCheck .lconnPickerSourceLabel:hover {
+    color: #FFFFFF !important;
+    background-color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+  body.lconnShareboxGadget .dijitTabInner.dijitTabContent:focus,
+  body.lconnShareboxGadget .lconnPickerSourceToCheck .lconnPickerSourceLabel:focus {
+    color: #595859 !important;
+    background-color: transparent !important;
+    border-color: #3C6DF0 !important;
+    outline: none !important; }
+  body.lconnShareboxGadget .dijitTabInner.dijitTabContent img,
+  body.lconnShareboxGadget .lconnPickerSourceToCheck .lconnPickerSourceLabel img {
+    left: .75rem;
+    position: absolute; }
+    body.lconnShareboxGadget .dijitTabInner.dijitTabContent img[class*="Folder"],
+    body.lconnShareboxGadget .lconnPickerSourceToCheck .lconnPickerSourceLabel img[class*="Folder"] {
+      left: .25rem; }
+
+body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"],
+body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"], body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:hover, body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:active, body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:focus,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"],
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:hover,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:active,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:hover, body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:active,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:hover,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:active {
+    outline: none; }
+  body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:focus,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:focus, .dijit_a11y body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:focus,
+  .dj_a11y body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:focus,
+  .dijit_a11y body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:active, body.lotusui30_body > .uploadFileGadgetDiv button[id="lconn_btn_browse_files"]:hover,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:active,
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="submit"]:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #FFFFFF !important;
+  border-color: #3C6DF0 !important;
+  color: #3C6DF0 !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"], body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:hover, body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:active, body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:hover, body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:active {
+    outline: none; }
+  body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:focus, .dijit_a11y body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:active, body.lotusui30_body > .uploadFileGadgetDiv input[value="Cancel"]:hover {
+    background-color: #3C6DF0 !important;
+    color: #FFFFFF !important;
+    border-color: #3C6DF0 !important; }
+body.lotusui30_body > .uploadFileGadgetDiv a[id^="additionalOptions"]:focus {
+  outline: none !important; }
+body.lotusui30_body > .uploadFileGadgetDiv input[type="text"] {
+  line-height: 1.5 !important;
+  padding: 0 !important;
+  background: none !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  font-size: 12.8px !important;
+  padding-right: 1rem !important;
+  padding-bottom: .375rem !important;
+  box-sizing: border-box !important;
+  height: auto !important;
+  padding-bottom: 11px !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv input[type="text"]:focus, body.lotusui30_body > .uploadFileGadgetDiv input[type="text"] .dijitTextBoxFocused {
+    outline: none !important;
+    border-color: #3C6DF0 !important;
+    box-shadow: 0 1px 0 #3C6DF0 !important; }
+body.lotusui30_body > .uploadFileGadgetDiv select {
+  font-size: 12.8px !important;
+  -webkit-appearance: none !important;
+  -moz-appearance: none !important;
+  appearance: none !important;
+  display: block !important;
+  width: auto !important;
+  min-width: 50% !important;
+  max-width: 100% !important;
+  padding: 0 2.75rem 0.75rem 0 !important;
+  color: #000000 !important;
+  background-color: transparent !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  border-radius: 0 !important;
+  cursor: pointer !important;
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 version=%221.1%22 x=%220px%22 y=%220px%22 viewBox=%220 0 12 7.5%22%3E%3Cpath fill=%22%23595859%22 d=%22M10.6,0L6,4.7L1.4,0L0,1.4l6,6.1l6-6.1L10.6,0z%22/%3E%3C/svg%3E") !important;
+  background-size: 0.75rem !important;
+  background-position: right .4rem !important;
+  background-repeat: no-repeat !important;
+  height: auto !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv select:focus {
+    border-bottom: 2px solid #3C6DF0 !important;
+    outline: none !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv select[disabled] {
+    cursor: not-allowed !important;
+    color: #969696 !important; }
+body.lotusui30_body > .uploadFileGadgetDiv textarea {
+  background-color: #F3F3F3 !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  padding: 1rem !important;
+  min-height: 3rem !important;
+  box-sizing: border-box !important; }
+  body.lotusui30_body > .uploadFileGadgetDiv textarea:focus {
+    outline: none !important;
+    border-color: #3C6DF0 !important;
+    box-shadow: 0 1px 0 #3C6DF0 !important; }
+
+div[id^="com_ibm_social_sharebox_controls_TabContainer"] {
+  margin-left: .5rem !important; }
+  div[id^="com_ibm_social_sharebox_controls_TabContainer"] .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked .tabLabel:hover {
+    color: #FFFFFF !important;
+    background-color: #3C6DF0 !important; }
+  div[id^="com_ibm_social_sharebox_controls_TabContainer"] .dijitTabInner.dijitTabContent.dijitTabHover {
+    background-color: transparent !important; }
+  div[id^="com_ibm_social_sharebox_controls_TabContainer"] .tabLabel {
+    margin-bottom: 0 !important; }
 
 /*# sourceMappingURL=global.css.map */

--- a/css/home.css
+++ b/css/home.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8429,6 +8487,39 @@ input[type="file"] {
     .lotusStream ul.lotusStream > li .activityStreamNewsItemContainer .lotusPostContent .fileBody {
       margin-left: 50px !important;
       padding: 10px 6px 0px 6px !important; }
+    .lotusStream ul.lotusStream > li .activityStreamNewsItemContainer img[src$="survey_draft_32.png"] {
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      width: 32px;
+      height: 32px;
+      background-image: url("data:image/svg+xml;charset=utf8,%3Csvg version=%221.1%22 xmlns=%22http://www.w3.org/2000/svg%22 x=%220px%22 y=%220px%22 viewBox=%220 0 24 24%22%3E%3Cpath d=%22M15 5h-3v1h3V5zM18 7h-6v1h6V7zM15 11h-3v1h3v-1zM9 17v2H7v-2h2m1-1H6v4h4v-4zM9 11v2H7v-2h2m1-1H6v4h4v-4zM9 5v2H7V5h2m1-1H6v4h4V4zM14.59 13H12v1h1.59l1-1z%22/%3E%3Cpath d=%22M20 16.41V22a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v6a3 3 0 0 1 1-.18V2a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6.59z%22/%3E%3Cpath d=%22M22.59 9.59l-.17-.17a2 2 0 0 0-2.83 0L12 17v3h3l7.59-7.59a2 2 0 0 0 0-2.82zm-8 9.41H13v-1.59l5.85-5.85 1.59 1.59zm7.29-7.29l-.73.73-1.59-1.59.73-.73a1 1 0 0 1 1.41 0l.17.17a1 1 0 0 1 0 1.41z%22/%3E%3C/svg%3E") !important;
+      background-size: 32px 32px;
+      background-position: 0 0 !important;
+      background-repeat: no-repeat !important;
+      margin-top: 4px !important;
+      padding-left: 32px; }
+    .lotusStream ul.lotusStream > li .activityStreamNewsItemContainer img[src$="survey_incomplete_32.png"] {
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      width: 32px;
+      height: 32px;
+      background-image: url("data:image/svg+xml;charset=utf8,%3Csvg version=%221.1%22 xmlns=%22http://www.w3.org/2000/svg%22 x=%220px%22 y=%220px%22 viewBox=%220 0 24 24%22%3E%3Cpath d=%22M15 5h-3v1h3V5zM18 7h-6v1h6V7zM15 11h-3v1h3v-1zM9 17v2H7v-2h2m1-1H6v4h4v-4zM9 11v2H7v-2h2m1-1H6v4h4v-4zM9 5v2H7V5h2m1-1H6v4h4V4zM14.59 13H12v1h1.59l1-1z%22/%3E%3Cpath d=%22M20 16.41V22a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v6a3 3 0 0 1 1-.18V2a2 2 0 0 0-2-2H5a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-6.59z%22/%3E%3Cpath d=%22M22.59 9.59l-.17-.17a2 2 0 0 0-2.83 0L12 17v3h3l7.59-7.59a2 2 0 0 0 0-2.82zm-8 9.41H13v-1.59l5.85-5.85 1.59 1.59zm7.29-7.29l-.73.73-1.59-1.59.73-.73a1 1 0 0 1 1.41 0l.17.17a1 1 0 0 1 0 1.41z%22/%3E%3C/svg%3E") !important;
+      background-size: 32px 32px;
+      background-position: 0 0 !important;
+      background-repeat: no-repeat !important;
+      margin-top: 4px !important;
+      padding-left: 32px; }
+    .lotusStream ul.lotusStream > li .activityStreamNewsItemContainer img[src$="survey_complete_32.png"] {
+      -moz-box-sizing: border-box;
+      box-sizing: border-box;
+      width: 32px;
+      height: 32px;
+      background-image: url("data:image/svg+xml;charset=utf8,%3Csvg version=%221.1%22 xmlns=%22http://www.w3.org/2000/svg%22 x=%220px%22 y=%220px%22 viewBox=%220 0 24 24%22%3E%3Cpath d=%22M7 13.29l-1.15-1.14-.7.7L7 14.71l3.85-3.86-.7-.7L7 13.29zM7 7.29L5.85 6.15l-.7.7L7 8.71l3.85-3.86-.7-.7L7 7.29zM12 5h3v1h-3zM12 7h6v1h-6zM12 11h3v1h-3zM12 13h6v1h-6zM12 17h3v1h-3zM12 19h6v1h-6z%22/%3E%3Cpath d=%22M19 0H5a2 2 0 0 0-2 2v20a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2zm1 22a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1z%22/%3E%3Cpath d=%22M6 20h4v-4H6zm1-3h2v2H7z%22/%3E%3C/svg%3E") !important;
+      background-size: 32px 32px;
+      background-position: 0 0 !important;
+      background-repeat: no-repeat !important;
+      margin-top: 4px !important;
+      padding-left: 32px; }
 
 div[dojoattachpoint="recommendContainer"] a {
   color: #000000 !important; }

--- a/css/meetings.css
+++ b/css/meetings.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,

--- a/css/profiles.css
+++ b/css/profiles.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8277,7 +8335,7 @@ div[class$="directory"] div:focus {
   .sc .lotusStream .scdirectory > a {
     padding: .5rem !important;
     margin: 0 !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     font-weight: normal !important; }
     @media only screen and (min-width: 0px) {
       .sc .lotusStream .scdirectory > a {
@@ -8312,7 +8370,7 @@ div[class$="directory"] div:focus {
     display: flex;
     flex-direction: row;
     padding: 1.5rem 3.5rem 1.5rem 1.5rem;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     position: relative; }
     .sc .lotusStream .scdirectory .sccontact .ccMember .lotusFloatContent,
     .sc .lotusStream .scdirectory .sccontact .ccMember .memberRightWrap,
@@ -8365,7 +8423,7 @@ div[class$="directory"] div:focus {
           margin: 0 auto 10px !important;
           padding: 0 !important;
           display: inline-block;
-          box-sizing: border-box;
+          box-sizing: border-box !important;
           width: 20px !important;
           height: 20px !important; }
           .sc .lotusStream .scdirectory .sccontact .ccMember .actionGroup .lotusBtnContainer .scActionIcon:nth-child(2) img {
@@ -8493,7 +8551,7 @@ div[id^="lconn_sand_ImageStream_"] a {
   #recent-friends-container .lotusChunk .lotusNetworkPerson {
     padding: 1rem 3px 0 !important;
     width: 33%;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     text-align: center;
     position: relative; }
     #recent-friends-container .lotusChunk .lotusNetworkPerson .vcard {
@@ -8603,7 +8661,8 @@ div[id^="lconn_sand_ImageStream_"] a {
   #filesReaderSection html.lconnFiles.files-enable-recent-view .lotusTopNav #lotusToolBar .toolActions,
   #filesReaderSection html.lconnFiles.files-enable-refine-panel .lotusTopNav #lotusToolBar .toolActions,
   #filesReaderSection html.lconnFiles.files-enable-simplify-left-nav .lotusTopNav #lotusToolBar .toolActions {
-    width: 182px; }
+    width: 182px;
+    box-sizing: content-box !important; }
     #filesReaderSection html.lconnFiles.files-enable-recent-view .lotusTopNav #lotusToolBar .toolActions .actionOn:after,
     #filesReaderSection html.lconnFiles.files-enable-refine-panel .lotusTopNav #lotusToolBar .toolActions .actionOn:after,
     #filesReaderSection html.lconnFiles.files-enable-simplify-left-nav .lotusTopNav #lotusToolBar .toolActions .actionOn:after {
@@ -8743,7 +8802,8 @@ div[id^="lconn_sand_ImageStream_"] a {
   #filesReaderSection div.filesListFilled #scene-body tr:not(.hentry) td.lotusFirstCell {
     top: 0 !important; }
     #filesReaderSection div.filesListFilled #scene-body tr:not(.hentry) td.lotusFirstCell .lotusCheckbox {
-      padding-top: 6px; }
+      padding-top: 6px;
+      margin-top: 2px; }
   #filesReaderSection div.filesListFilled #scene-body tr.hentry td.lotusFirstCell input {
     margin: 0 !important; }
   #filesReaderSection tr.hentry td.lotusAlignRight {
@@ -9111,7 +9171,7 @@ div[id^="lconn_news_microblogging_sharebox_InputForm_"][id$="_textBoxContainer"]
 #profilePaneRight {
   width: 300px;
   margin-left: 3.25rem;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .lotusWidget2 {
   margin-bottom: 3rem !important; }
@@ -9199,7 +9259,7 @@ div[id^="tabsWidget"] .lotusWidget2 h2 {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -9419,7 +9479,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -9461,7 +9521,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -9549,7 +9609,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -9723,7 +9783,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -10081,7 +10141,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -10542,7 +10602,7 @@ div[id^="com_ibm_sc_widget_SlideDialog_"] .lotusBtn[data-dojo-attach-point="canc
         width: calc(50% - 1rem) !important; }
     .lconn_directoryPage .lconn_content .lconn_resultContainer.lconnSearchHighlight > div .lconn_personContainer {
       border: 2px solid transparent;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       box-shadow: 0px 2px 5px rgba(0, 0, 0, 0.3);
       padding: 1.5rem 3.5rem 1.5rem 1.5rem;
       margin: .5rem !important;

--- a/css/search.css
+++ b/css/search.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8248,7 +8306,7 @@ input[type="file"] {
   position: relative !important;
   top: -15px !important;
   margin-left: 0px !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .lotusui.lotusui30dojo.lotusui30_body .lotusFrame .lotusColLeft .lotusMenu {
     width: 240px;
     position: relative !important;

--- a/css/settings.css
+++ b/css/settings.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8473,7 +8531,7 @@ input[type="file"] {
       display: block;
       border: none !important;
       transition: border 0.23s ease, padding 0.23s ease !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       font-weight: normal !important; }
       .lotusMain #lotusColLeft h3 + .lotusMenuSubsection > ul > li a:hover,
       .lotusMain .lotusColLeft h3 + .lotusMenuSubsection > ul > li a:hover {

--- a/css/surveys.css
+++ b/css/surveys.css
@@ -14,8 +14,7 @@
 	 * implied. See the License for the specific language governing
 	 * permissions and limitations under the License.
 */
-/*METRICS STYLE SHEET*/
-/* Variable and mixin Imports*/
+/* SURVEYS STYLE SHEET */
 /* Border radius */
 /* Box Shadows */
 /* Note - May also need to include a display:none on an existing button img */
@@ -8646,6 +8645,155 @@ input[type="file"] {
         background-color: transparent !important;
         color: #595859 !important; }
 
+#comments {
+  padding-left: 0px !important; }
+  #comments .qkrAddComment.lotusForm .cke_contents {
+    width: 100% !important;
+    min-width: 240px !important;
+    background-color: #F3F3F3 !important;
+    border: none !important;
+    border-bottom: 2px solid #3C6DF0 !important; }
+  #comments .lotusFeeds.lotusMeta {
+    padding-left: 10px; }
+  #comments .lconnRTE,
+  #comments .lotusFormFooter {
+    padding-left: 0 !important; }
+    #comments .lconnRTE input[type="submit"],
+    #comments .lotusFormFooter input[type="submit"] {
+      border-radius: 2rem !important;
+      border-width: 1px !important;
+      border-style: solid !important;
+      box-shadow: none !important;
+      transform: translateZ(0) !important;
+      -webkit-font-smoothing: antialiased !important;
+      cursor: pointer !important;
+      -webkit-box-align: center !important;
+      -webkit-box-pack: center !important;
+      text-align: center !important;
+      transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+      white-space: nowrap !important;
+      padding: 9px 20px !important;
+      background-image: none !important;
+      margin: 2px 4px 3px 2px !important;
+      background-color: #3C6DF0 !important;
+      border-color: #3C6DF0 !important;
+      color: #FFFFFF !important; }
+      #comments .lconnRTE input[type="submit"], #comments .lconnRTE input[type="submit"]:hover, #comments .lconnRTE input[type="submit"]:active, #comments .lconnRTE input[type="submit"]:focus,
+      #comments .lotusFormFooter input[type="submit"],
+      #comments .lotusFormFooter input[type="submit"]:hover,
+      #comments .lotusFormFooter input[type="submit"]:active,
+      #comments .lotusFormFooter input[type="submit"]:focus {
+        text-decoration: none !important;
+        font-weight: 500 !important; }
+      #comments .lconnRTE input[type="submit"]:hover, #comments .lconnRTE input[type="submit"]:active,
+      #comments .lotusFormFooter input[type="submit"]:hover,
+      #comments .lotusFormFooter input[type="submit"]:active {
+        outline: none; }
+      #comments .lconnRTE input[type="submit"]:focus,
+      #comments .lotusFormFooter input[type="submit"]:focus {
+        box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+        outline: none !important; }
+      .dj_a11y #comments .lconnRTE input[type="submit"]:focus, .dijit_a11y #comments .lconnRTE input[type="submit"]:focus,
+      .dj_a11y #comments .lotusFormFooter input[type="submit"]:focus,
+      .dijit_a11y #comments .lotusFormFooter input[type="submit"]:focus {
+        box-shadow: none !important;
+        outline: 1px solid #3C6DF0 !important;
+        outline-offset: 1px; }
+      #comments .lconnRTE input[type="submit"]:active, #comments .lconnRTE input[type="submit"]:hover,
+      #comments .lotusFormFooter input[type="submit"]:active,
+      #comments .lotusFormFooter input[type="submit"]:hover {
+        background-color: #FFFFFF !important;
+        color: #3C6DF0 !important;
+        border-color: #3C6DF0 !important; }
+
+.lotusui30 div[id^="section_eventcomments_"] div[dojoattachpoint="noCommentHintAP"] {
+  padding-bottom: 20px; }
+.lotusui30 div[id^="section_eventcomments_"] div[id$="_commentList"] {
+  padding-bottom: 20px; }
+  .lotusui30 div[id^="section_eventcomments_"] div[id$="_commentList"] .lotusMeta {
+    font-size: 12px !important;
+    font-weight: 500 !important; }
+    .lotusui30 div[id^="section_eventcomments_"] div[id$="_commentList"] .lotusMeta span.vcard {
+      margin-bottom: 0px; }
+.lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"] {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #FFFFFF !important;
+  border-color: #3C6DF0 !important;
+  color: #3C6DF0 !important; }
+  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"], .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:hover, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:active, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:hover, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:active {
+    outline: none; }
+  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus, .dijit_a11y .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:active, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:hover {
+    background-color: #3C6DF0 !important;
+    color: #FFFFFF !important;
+    border-color: #3C6DF0 !important; }
+.lotusui30 div[id^="section_eventcomments_"] .lotusForm2 {
+  padding-top: 10px; }
+  .lotusui30 div[id^="section_eventcomments_"] .lotusForm2 .lconnRTE [id^="cke_editor"] {
+    width: 100%; }
+    .lotusui30 div[id^="section_eventcomments_"] .lotusForm2 .lconnRTE [id^="cke_editor"] .cke_contents {
+      width: 100% !important;
+      min-width: 240px !important;
+      border: none !important;
+      border-bottom: 2px solid #3C6DF0 !important; }
+
+#blogCommentPanel #blogAddCommentForm .lotusPostContent {
+  display: inline; }
+  #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormTitle {
+    padding-top: 0px; }
+  #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody {
+    padding-left: 0px;
+    padding-right: 0px; }
+    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody [id^="cke_editor"] {
+      width: 100% !important; }
+      #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody [id^="cke_editor"] .cke_contents {
+        outline: none !important;
+        padding: 0 !important;
+        min-width: 240px !important;
+        background-color: #F3F3F3 !important;
+        border: none !important;
+        border-bottom: 2px solid #3C6DF0 !important; }
+    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody input#postCommentAsTrackback {
+      margin-left: 2px; }
+    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody label {
+      margin-top: 3px; }
+    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody div[dojoattachpoint="selectBlogAP"] {
+      padding-top: 10px; }
+      #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody div[dojoattachpoint="selectBlogAP"] select#postCommentAsTrackbackWeblogSelect {
+        margin-left: 0px !important; }
+  #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormFooter {
+    padding-left: 0px;
+    padding-right: 0px; }
+
+#comments div[id^="lconn_wikis_widget_CommentsMentions_"] div.lotusMeta, #comments div[id^="lconn_wikis_widget_CommentsMentions_"] .lotusMeta > a, #comments div[id^="lconn_wikis_widget_CommentsMentions_"] .lotusMeta > span {
+  font-size: 12px !important;
+  font-weight: 500 !important; }
+#comments div[id^="lconn_wikis_widget_CommentsMentions_"] .lotusMeta > span {
+  margin-bottom: 0px !important; }
+
 #body .lconnPickerSourceArea .headerSelector .checkbox {
   margin-top: 5px !important; }
 #body .lconnPickerSourceArea .headerSelector .icon img.lconn-ftype16 {
@@ -10894,155 +11042,6 @@ form.lotusForm.qkrEdit .lotusTabs.aria_toolbar {
 div[id^="lconn_share0_widget_Dialog_"] form .lotusDialogContent._qkrDialogCompact {
   padding: 0 !important; }
 
-#comments {
-  padding-left: 0px !important; }
-  #comments .qkrAddComment.lotusForm .cke_contents {
-    width: 100% !important;
-    min-width: 240px !important;
-    background-color: #F3F3F3 !important;
-    border: none !important;
-    border-bottom: 2px solid #3C6DF0 !important; }
-  #comments .lotusFeeds.lotusMeta {
-    padding-left: 10px; }
-  #comments .lconnRTE,
-  #comments .lotusFormFooter {
-    padding-left: 0 !important; }
-    #comments .lconnRTE input[type="submit"],
-    #comments .lotusFormFooter input[type="submit"] {
-      border-radius: 2rem !important;
-      border-width: 1px !important;
-      border-style: solid !important;
-      box-shadow: none !important;
-      transform: translateZ(0) !important;
-      -webkit-font-smoothing: antialiased !important;
-      cursor: pointer !important;
-      -webkit-box-align: center !important;
-      -webkit-box-pack: center !important;
-      text-align: center !important;
-      transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
-      white-space: nowrap !important;
-      padding: 9px 20px !important;
-      background-image: none !important;
-      margin: 2px 4px 3px 2px !important;
-      background-color: #3C6DF0 !important;
-      border-color: #3C6DF0 !important;
-      color: #FFFFFF !important; }
-      #comments .lconnRTE input[type="submit"], #comments .lconnRTE input[type="submit"]:hover, #comments .lconnRTE input[type="submit"]:active, #comments .lconnRTE input[type="submit"]:focus,
-      #comments .lotusFormFooter input[type="submit"],
-      #comments .lotusFormFooter input[type="submit"]:hover,
-      #comments .lotusFormFooter input[type="submit"]:active,
-      #comments .lotusFormFooter input[type="submit"]:focus {
-        text-decoration: none !important;
-        font-weight: 500 !important; }
-      #comments .lconnRTE input[type="submit"]:hover, #comments .lconnRTE input[type="submit"]:active,
-      #comments .lotusFormFooter input[type="submit"]:hover,
-      #comments .lotusFormFooter input[type="submit"]:active {
-        outline: none; }
-      #comments .lconnRTE input[type="submit"]:focus,
-      #comments .lotusFormFooter input[type="submit"]:focus {
-        box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
-        outline: none !important; }
-      .dj_a11y #comments .lconnRTE input[type="submit"]:focus, .dijit_a11y #comments .lconnRTE input[type="submit"]:focus,
-      .dj_a11y #comments .lotusFormFooter input[type="submit"]:focus,
-      .dijit_a11y #comments .lotusFormFooter input[type="submit"]:focus {
-        box-shadow: none !important;
-        outline: 1px solid #3C6DF0 !important;
-        outline-offset: 1px; }
-      #comments .lconnRTE input[type="submit"]:active, #comments .lconnRTE input[type="submit"]:hover,
-      #comments .lotusFormFooter input[type="submit"]:active,
-      #comments .lotusFormFooter input[type="submit"]:hover {
-        background-color: #FFFFFF !important;
-        color: #3C6DF0 !important;
-        border-color: #3C6DF0 !important; }
-
-.lotusui30 div[id^="section_eventcomments_"] div[dojoattachpoint="noCommentHintAP"] {
-  padding-bottom: 20px; }
-.lotusui30 div[id^="section_eventcomments_"] div[id$="_commentList"] {
-  padding-bottom: 20px; }
-  .lotusui30 div[id^="section_eventcomments_"] div[id$="_commentList"] .lotusMeta {
-    font-size: 12px !important;
-    font-weight: 500 !important; }
-    .lotusui30 div[id^="section_eventcomments_"] div[id$="_commentList"] .lotusMeta span.vcard {
-      margin-bottom: 0px; }
-.lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"] {
-  border-radius: 2rem !important;
-  border-width: 1px !important;
-  border-style: solid !important;
-  box-shadow: none !important;
-  transform: translateZ(0) !important;
-  -webkit-font-smoothing: antialiased !important;
-  cursor: pointer !important;
-  -webkit-box-align: center !important;
-  -webkit-box-pack: center !important;
-  text-align: center !important;
-  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
-  white-space: nowrap !important;
-  padding: 9px 20px !important;
-  background-image: none !important;
-  margin: 2px 4px 3px 2px !important;
-  background-color: #FFFFFF !important;
-  border-color: #3C6DF0 !important;
-  color: #3C6DF0 !important; }
-  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"], .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:hover, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:active, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus {
-    text-decoration: none !important;
-    font-weight: 500 !important; }
-  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:hover, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:active {
-    outline: none; }
-  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus {
-    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
-    outline: none !important; }
-  .dj_a11y .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus, .dijit_a11y .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:focus {
-    box-shadow: none !important;
-    outline: 1px solid #3C6DF0 !important;
-    outline-offset: 1px; }
-  .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:active, .lotusui30 div[id^="section_eventcomments_"] a[id$="_addCommentLink"]:hover {
-    background-color: #3C6DF0 !important;
-    color: #FFFFFF !important;
-    border-color: #3C6DF0 !important; }
-.lotusui30 div[id^="section_eventcomments_"] .lotusForm2 {
-  padding-top: 10px; }
-  .lotusui30 div[id^="section_eventcomments_"] .lotusForm2 .lconnRTE [id^="cke_editor"] {
-    width: 100%; }
-    .lotusui30 div[id^="section_eventcomments_"] .lotusForm2 .lconnRTE [id^="cke_editor"] .cke_contents {
-      width: 100% !important;
-      min-width: 240px !important;
-      border: none !important;
-      border-bottom: 2px solid #3C6DF0 !important; }
-
-#blogCommentPanel #blogAddCommentForm .lotusPostContent {
-  display: inline; }
-  #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormTitle {
-    padding-top: 0px; }
-  #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody {
-    padding-left: 0px;
-    padding-right: 0px; }
-    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody [id^="cke_editor"] {
-      width: 100% !important; }
-      #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody [id^="cke_editor"] .cke_contents {
-        outline: none !important;
-        padding: 0 !important;
-        min-width: 240px !important;
-        background-color: #F3F3F3 !important;
-        border: none !important;
-        border-bottom: 2px solid #3C6DF0 !important; }
-    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody input#postCommentAsTrackback {
-      margin-left: 2px; }
-    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody label {
-      margin-top: 3px; }
-    #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody div[dojoattachpoint="selectBlogAP"] {
-      padding-top: 10px; }
-      #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormBody div[dojoattachpoint="selectBlogAP"] select#postCommentAsTrackbackWeblogSelect {
-        margin-left: 0px !important; }
-  #blogCommentPanel #blogAddCommentForm .lotusPostContent .lotusFormFooter {
-    padding-left: 0px;
-    padding-right: 0px; }
-
-#comments div[id^="lconn_wikis_widget_CommentsMentions_"] div.lotusMeta, #comments div[id^="lconn_wikis_widget_CommentsMentions_"] .lotusMeta > a, #comments div[id^="lconn_wikis_widget_CommentsMentions_"] .lotusMeta > span {
-  font-size: 12px !important;
-  font-weight: 500 !important; }
-#comments div[id^="lconn_wikis_widget_CommentsMentions_"] .lotusMeta > span {
-  margin-bottom: 0px !important; }
-
 #lotusInfoBox {
   margin: 0 !important;
   padding: 32px !important;
@@ -11051,438 +11050,173 @@ div[id^="lconn_share0_widget_Dialog_"] form .lotusDialogContent._qkrDialogCompac
     border: none !important;
     background-color: #F3F3F3 !important; }
 
-.lotusContent {
-  margin-top: 32px !important; }
-  .lotusContent .metricsDateRangeFilter label, .lotusContent .metricsDateRangeFilter select,
-  .lotusContent #selectDropDownContainerID label,
-  .lotusContent #selectDropDownContainerID select,
-  .lotusContent #divGroupByFilterID label,
-  .lotusContent #divGroupByFilterID select {
-    font-size: 14px !important;
-    font-weight: 400 !important; }
+div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] {
+  top: -30px !important; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top {
+    height: 68px !important; }
+    div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top .dijitTabListWrapper {
+      height: auto !important; }
+    div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+      padding-bottom: calc(.375rem + 3px) !important; }
+      div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTab {
+        padding: 0.625rem 0 0.375rem 0 !important;
+        margin: 0 0 0 1rem !important;
+        border-bottom: none !important; }
+        div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTab.dijitTabChecked {
+          border-bottom: 4px solid #3C6DF0 !important; }
+        div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTab .dijitTabInner.dijitTabContent {
+          margin-left: 0 !important; }
+          div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTab .dijitTabInner.dijitTabContent span {
+            padding: 0.5rem 1rem !important;
+            color: #595859 !important;
+            border: 1px solid transparent !important;
+            font-size: 14px !important;
+            font-weight: 600 !important; }
+            div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTab .dijitTabInner.dijitTabContent span:focus {
+              text-decoration: none !important;
+              border-color: #3C6DF0 !important;
+              color: #595859 !important; }
+            div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTab .dijitTabInner.dijitTabContent span:hover {
+              border-color: #3C6DF0 !important;
+              background-color: #3C6DF0 !important;
+              color: #FFFFFF !important; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .lotusMessage img {
+    margin-top: 12px !important; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .dijitTabContainer .lotusMessage span {
+    font-size: 1.3em !important; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .lotusDialogFooter span.dijitButton.lotusFormButton .dijitButtonText {
+    font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .lotusDialogFooter span.dijitButton.lotusFormButton.dijitButtonHover {
+    background-color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+    div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .lotusDialogFooter span.dijitButton.lotusFormButton.dijitButtonHover .dijitButtonText {
+      color: #FFFFFF !important; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .lotusDialogFooter span.dijitButton.lotusFormButton.dijitButtonFocused {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #969696 !important; }
+  div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] .lotusDialogFooter .dijitButtonContents {
+    outline: none !important; }
 
-#dateRangeTextPID b {
-  color: #000000 !important;
-  font-size: 16px !important;
-  font-weight: 600 !important; }
+.lfSummaryWrapper div.dijitVisible {
+  top: 24px !important; }
+  .lfSummaryWrapper div.dijitVisible .dijitContentPane {
+    top: 0 !important;
+    left: 0 !important;
+    padding-top: 8px !important;
+    padding-bottom: 8px !important; }
+    .lfSummaryWrapper div.dijitVisible .dijitContentPane.lfOverviewToolbar {
+      padding: 0 !important; }
+.lfSummaryWrapper .lfViewResponseControls {
+  border-bottom: none !important; }
+  .lfSummaryWrapper .lfViewResponseControls .lotusInlinelist {
+    height: 54px !important;
+    bottom: 0 !important; }
+  .lfSummaryWrapper .lfViewResponseControls ul[role="tablist"] li {
+    padding: 0.625rem 0 0.375rem 0 !important;
+    margin: 0 0 0 1rem !important;
+    border-bottom: none !important; }
+    .lfSummaryWrapper .lfViewResponseControls ul[role="tablist"] li.active {
+      border-bottom: 4px solid #3C6DF0 !important; }
+    .lfSummaryWrapper .lfViewResponseControls ul[role="tablist"] li:focus {
+      outline: none !important; }
+    .lfSummaryWrapper .lfViewResponseControls ul[role="tablist"] li a {
+      padding: 0.5rem 1rem !important;
+      color: #595859 !important;
+      border: 1px solid transparent !important;
+      font-size: 14px !important;
+      font-weight: 600 !important; }
+      .lfSummaryWrapper .lfViewResponseControls ul[role="tablist"] li a:focus {
+        text-decoration: none !important;
+        border-color: #3C6DF0 !important; }
+      .lfSummaryWrapper .lfViewResponseControls ul[role="tablist"] li a:hover {
+        border-color: #3C6DF0 !important;
+        background-color: #3C6DF0 !important;
+        color: #FFFFFF !important; }
 
-#statisticHeadDivId .LineChartHeaderRectClz {
-  fill: #777677 !important; }
-#statisticHeadDivId .LineChartBodyRectClz {
-  fill: #F3F3F3 !important; }
-#statisticHeadDivId text.LineChartHeaderRectDespClz {
-  alignment-baseline: middle;
-  font-size: 16px !important; }
-#statisticHeadDivId text.LineChartBodyRectDespClz {
-  font-style: italic; }
-
-.metricsReport {
-  outline: none !important; }
-  .metricsReport#reportContainerDivID {
-    overflow-x: auto !important; }
-  .metricsReport #statisticHeadDivId,
-  .metricsReport #lineChartViewTable,
-  .metricsReport #appFilterDivId,
-  .metricsReport #reportDivId,
-  .metricsReport #lineChartTableDiv,
-  .metricsReport #hBarViewTable,
-  .metricsReport #hBarAppFilterDivId,
-  .metricsReport #hBarChartDivId {
-    width: 100% !important; }
-    .metricsReport #statisticHeadDivId svg,
-    .metricsReport #statisticHeadDivId g[class^="data-"] rect,
-    .metricsReport #lineChartViewTable svg,
-    .metricsReport #lineChartViewTable g[class^="data-"] rect,
-    .metricsReport #appFilterDivId svg,
-    .metricsReport #appFilterDivId g[class^="data-"] rect,
-    .metricsReport #reportDivId svg,
-    .metricsReport #reportDivId g[class^="data-"] rect,
-    .metricsReport #lineChartTableDiv svg,
-    .metricsReport #lineChartTableDiv g[class^="data-"] rect,
-    .metricsReport #hBarViewTable svg,
-    .metricsReport #hBarViewTable g[class^="data-"] rect,
-    .metricsReport #hBarAppFilterDivId svg,
-    .metricsReport #hBarAppFilterDivId g[class^="data-"] rect,
-    .metricsReport #hBarChartDivId svg,
-    .metricsReport #hBarChartDivId g[class^="data-"] rect {
-      width: 100% !important; }
-
-.metricsReport #rightMsgContainerDivID,
-.metricsReport #lineChartRightDivID {
-  margin-left: 20px; }
-  .metricsReport #rightMsgContainerDivID div,
-  .metricsReport #lineChartRightDivID div {
-    background-color: #FFFFFF !important;
-    color: #000000 !important;
-    font-size: 16px !important;
-    font-weight: 600 !important;
-    border-bottom: 1px solid #d8d8d8; }
-  .metricsReport #rightMsgContainerDivID span.warning,
-  .metricsReport #lineChartRightDivID span.warning {
-    white-space: normal;
-    display: block;
-    max-width: 260px;
-    padding: 20px 10px;
-    font-size: 20px !important;
-    font-weight: 300 !important; }
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID rect.topUHeaderRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID rect.topUHeaderRect {
-    fill: #FFFFFF !important;
-    border-bottom: 1px solid #d8d8d8; }
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID text.TopUHeaderRectDespClz,
-  .metricsReport #lineChartRightDivID #topUsersSvgID text.TopUHeaderRectDespClz {
-    fill: #000000 !important;
-    font-size: 16px !important;
-    font-weight: 600 !important; }
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(even) rect.topUItemHeader,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(even) rect.followedNoRect,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(even) rect.postsNoRect,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(even) rect.topUClearBlackLineRect,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(even) rect.topUItemBody,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(even) rect.topUItemHeader,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(even) rect.followedNoRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(even) rect.postsNoRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(even) rect.topUClearBlackLineRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(even) rect.topUItemBody {
-    fill: #F3F3F3 !important; }
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(odd) rect.topUItemHeader,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(odd) rect.followedNoRect,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(odd) rect.postsNoRect,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(odd) rect.topUClearBlackLineRect,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID > g:nth-child(odd) rect.topUItemBody,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(odd) rect.topUItemHeader,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(odd) rect.followedNoRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(odd) rect.postsNoRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(odd) rect.topUClearBlackLineRect,
-  .metricsReport #lineChartRightDivID #topUsersSvgID > g:nth-child(odd) rect.topUItemBody {
-    fill: #FFFFFF !important; }
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID text.postsNo,
-  .metricsReport #rightMsgContainerDivID #topUsersSvgID text.postText,
-  .metricsReport #lineChartRightDivID #topUsersSvgID text.postsNo,
-  .metricsReport #lineChartRightDivID #topUsersSvgID text.postText {
-    fill: #000000 !important; }
-  .metricsReport #rightMsgContainerDivID #topUViewTable a,
-  .metricsReport #rightMsgContainerDivID #topUViewChart a,
-  .metricsReport #lineChartRightDivID #topUViewTable a,
-  .metricsReport #lineChartRightDivID #topUViewChart a {
-    font-size: 12px !important;
-    font-weight: 500 !important; }
-
-#groupByTableDivID {
-  font-size: 14px !important;
-  font-weight: 400 !important; }
-  #groupByTableDivID table tr th, #groupByTableDivID table tr td {
-    padding-top: 6px;
-    padding-bottom: 6px; }
-
-#appFilterDivId .data-Total > rect {
-  fill: #777677 !important; }
-#appFilterDivId .appflitertext {
-  font-weight: bold !important; }
-
-#statisticHeaderTableID tbody tr > th {
-  font-size: 16px !important;
-  height: 2.4em !important;
-  padding-left: 0em !important; }
-#statisticHeaderTableID tbody tr > td {
-  padding-left: 0em !important; }
-#statisticHeaderTableID tbody tr:nth-child(3) {
-  font-style: italic; }
-
-#lineChartTableID tbody > tr:nth-child(1) > th {
-  background: #F3F3F3 !important; }
-#lineChartTableID tbody > tr > th:nth-child(n+2), #lineChartTableID td:nth-child(n+2) {
-  padding-left: 0em !important; }
-
-#reportContainerDivID td span:before,
-#reportContainerDivID th span:before,
-#hBarTableDiv td span:before,
-#hBarTableDiv th span:before,
-#lineChartTableID td span:before,
-#lineChartTableID th span:before,
-#hBarAppFilterDivId td span:before,
-#hBarAppFilterDivId th span:before {
-  width: 8px !important; }
-#reportContainerDivID td, #reportContainerDivID th,
-#hBarTableDiv td,
-#hBarTableDiv th,
-#lineChartTableID td,
-#lineChartTableID th,
-#hBarAppFilterDivId td,
-#hBarAppFilterDivId th {
-  padding-left: 1.6em !important; }
-#reportContainerDivID g[name="hBBottomBar"] rect,
-#hBarTableDiv g[name="hBBottomBar"] rect,
-#lineChartTableID g[name="hBBottomBar"] rect,
-#hBarAppFilterDivId g[name="hBBottomBar"] rect {
-  fill: #FFFFFF !important; }
-#reportContainerDivID #svgLine .line,
-#hBarTableDiv #svgLine .line,
-#lineChartTableID #svgLine .line,
-#hBarAppFilterDivId #svgLine .line {
-  stroke-width: 4 !important; }
-#reportContainerDivID .data-OVERALL > rect,
-#hBarTableDiv .data-OVERALL > rect,
-#lineChartTableID .data-OVERALL > rect,
-#hBarAppFilterDivId .data-OVERALL > rect {
-  fill: #777677 !important;
-  stroke: #777677 !important; }
-#reportContainerDivID .data-ACTIVITIES.line,
-#hBarTableDiv .data-ACTIVITIES.line,
-#lineChartTableID .data-ACTIVITIES.line,
-#hBarAppFilterDivId .data-ACTIVITIES.line {
-  stroke: #e62325 !important; }
-#reportContainerDivID .data-ACTIVITIES rect,
-#hBarTableDiv .data-ACTIVITIES rect,
-#lineChartTableID .data-ACTIVITIES rect,
-#hBarAppFilterDivId .data-ACTIVITIES rect {
-  fill: #e62325 !important;
-  stroke: #e62325 !important; }
-#reportContainerDivID .data-ACTIVITIES td span:before,
-#reportContainerDivID .data-ACTIVITIES th span:before,
-#reportContainerDivID .data-ACTIVITIES td:first-child span:before,
-#hBarTableDiv .data-ACTIVITIES td span:before,
-#hBarTableDiv .data-ACTIVITIES th span:before,
-#hBarTableDiv .data-ACTIVITIES td:first-child span:before,
-#lineChartTableID .data-ACTIVITIES td span:before,
-#lineChartTableID .data-ACTIVITIES th span:before,
-#lineChartTableID .data-ACTIVITIES td:first-child span:before,
-#hBarAppFilterDivId .data-ACTIVITIES td span:before,
-#hBarAppFilterDivId .data-ACTIVITIES th span:before,
-#hBarAppFilterDivId .data-ACTIVITIES td:first-child span:before {
-  background-color: #e62325 !important; }
-#reportContainerDivID .data-BLOGS.line,
-#hBarTableDiv .data-BLOGS.line,
-#lineChartTableID .data-BLOGS.line,
-#hBarAppFilterDivId .data-BLOGS.line {
-  stroke: #00884b !important; }
-#reportContainerDivID .data-BLOGS rect,
-#hBarTableDiv .data-BLOGS rect,
-#lineChartTableID .data-BLOGS rect,
-#hBarAppFilterDivId .data-BLOGS rect {
-  fill: #00884b !important;
-  stroke: #00884b !important; }
-#reportContainerDivID .data-BLOGS td span:before,
-#reportContainerDivID .data-BLOGS th span:before,
-#reportContainerDivID .data-BLOGS td:first-child span:before,
-#hBarTableDiv .data-BLOGS td span:before,
-#hBarTableDiv .data-BLOGS th span:before,
-#hBarTableDiv .data-BLOGS td:first-child span:before,
-#lineChartTableID .data-BLOGS td span:before,
-#lineChartTableID .data-BLOGS th span:before,
-#lineChartTableID .data-BLOGS td:first-child span:before,
-#hBarAppFilterDivId .data-BLOGS td span:before,
-#hBarAppFilterDivId .data-BLOGS th span:before,
-#hBarAppFilterDivId .data-BLOGS td:first-child span:before {
-  background-color: #00884b !important; }
-#reportContainerDivID .data-BOOKMARKS.line,
-#hBarTableDiv .data-BOOKMARKS.line,
-#lineChartTableID .data-BOOKMARKS.line,
-#hBarAppFilterDivId .data-BOOKMARKS.line {
-  stroke: #dc267f !important; }
-#reportContainerDivID .data-BOOKMARKS rect,
-#hBarTableDiv .data-BOOKMARKS rect,
-#lineChartTableID .data-BOOKMARKS rect,
-#hBarAppFilterDivId .data-BOOKMARKS rect {
-  fill: #dc267f !important;
-  stroke: #dc267f !important; }
-#reportContainerDivID .data-BOOKMARKS td span:before,
-#reportContainerDivID .data-BOOKMARKS th span:before,
-#reportContainerDivID .data-BOOKMARKS td:first-child span:before,
-#hBarTableDiv .data-BOOKMARKS td span:before,
-#hBarTableDiv .data-BOOKMARKS th span:before,
-#hBarTableDiv .data-BOOKMARKS td:first-child span:before,
-#lineChartTableID .data-BOOKMARKS td span:before,
-#lineChartTableID .data-BOOKMARKS th span:before,
-#lineChartTableID .data-BOOKMARKS td:first-child span:before,
-#hBarAppFilterDivId .data-BOOKMARKS td span:before,
-#hBarAppFilterDivId .data-BOOKMARKS th span:before,
-#hBarAppFilterDivId .data-BOOKMARKS td:first-child span:before {
-  background-color: #dc267f !important; }
-#reportContainerDivID .data-COMMUNITIES.line,
-#hBarTableDiv .data-COMMUNITIES.line,
-#lineChartTableID .data-COMMUNITIES.line,
-#hBarAppFilterDivId .data-COMMUNITIES.line {
-  stroke: #008673 !important; }
-#reportContainerDivID .data-COMMUNITIES rect,
-#hBarTableDiv .data-COMMUNITIES rect,
-#lineChartTableID .data-COMMUNITIES rect,
-#hBarAppFilterDivId .data-COMMUNITIES rect {
-  fill: #008673 !important;
-  stroke: #008673 !important; }
-#reportContainerDivID .data-COMMUNITIES td span:before,
-#reportContainerDivID .data-COMMUNITIES th span:before,
-#reportContainerDivID .data-COMMUNITIES td:first-child span:before,
-#hBarTableDiv .data-COMMUNITIES td span:before,
-#hBarTableDiv .data-COMMUNITIES th span:before,
-#hBarTableDiv .data-COMMUNITIES td:first-child span:before,
-#lineChartTableID .data-COMMUNITIES td span:before,
-#lineChartTableID .data-COMMUNITIES th span:before,
-#lineChartTableID .data-COMMUNITIES td:first-child span:before,
-#hBarAppFilterDivId .data-COMMUNITIES td span:before,
-#hBarAppFilterDivId .data-COMMUNITIES th span:before,
-#hBarAppFilterDivId .data-COMMUNITIES td:first-child span:before {
-  background-color: #008673 !important; }
-#reportContainerDivID .data-FILES.line,
-#hBarTableDiv .data-FILES.line,
-#lineChartTableID .data-FILES.line,
-#hBarAppFilterDivId .data-FILES.line {
-  stroke: #3C6DF0 !important; }
-#reportContainerDivID .data-FILES rect,
-#hBarTableDiv .data-FILES rect,
-#lineChartTableID .data-FILES rect,
-#hBarAppFilterDivId .data-FILES rect {
-  fill: #3C6DF0 !important;
-  stroke: #3C6DF0 !important; }
-#reportContainerDivID .data-FILES td span:before,
-#reportContainerDivID .data-FILES th span:before,
-#reportContainerDivID .data-FILES td:first-child span:before,
-#hBarTableDiv .data-FILES td span:before,
-#hBarTableDiv .data-FILES th span:before,
-#hBarTableDiv .data-FILES td:first-child span:before,
-#lineChartTableID .data-FILES td span:before,
-#lineChartTableID .data-FILES th span:before,
-#lineChartTableID .data-FILES td:first-child span:before,
-#hBarAppFilterDivId .data-FILES td span:before,
-#hBarAppFilterDivId .data-FILES th span:before,
-#hBarAppFilterDivId .data-FILES td:first-child span:before {
-  background-color: #3C6DF0 !important; }
-#reportContainerDivID .data-FORUMS.line,
-#hBarTableDiv .data-FORUMS.line,
-#lineChartTableID .data-FORUMS.line,
-#hBarAppFilterDivId .data-FORUMS.line {
-  stroke: #9753e1 !important; }
-#reportContainerDivID .data-FORUMS rect,
-#hBarTableDiv .data-FORUMS rect,
-#lineChartTableID .data-FORUMS rect,
-#hBarAppFilterDivId .data-FORUMS rect {
-  fill: #9753e1 !important;
-  stroke: #9753e1 !important; }
-#reportContainerDivID .data-FORUMS td span:before,
-#reportContainerDivID .data-FORUMS th span:before,
-#reportContainerDivID .data-FORUMS td:first-child span:before,
-#hBarTableDiv .data-FORUMS td span:before,
-#hBarTableDiv .data-FORUMS th span:before,
-#hBarTableDiv .data-FORUMS td:first-child span:before,
-#lineChartTableID .data-FORUMS td span:before,
-#lineChartTableID .data-FORUMS th span:before,
-#lineChartTableID .data-FORUMS td:first-child span:before,
-#hBarAppFilterDivId .data-FORUMS td span:before,
-#hBarAppFilterDivId .data-FORUMS th span:before,
-#hBarAppFilterDivId .data-FORUMS td:first-child span:before {
-  background-color: #9753e1 !important; }
-#reportContainerDivID .data-HOMEPAGE.line,
-#hBarTableDiv .data-HOMEPAGE.line,
-#lineChartTableID .data-HOMEPAGE.line,
-#hBarAppFilterDivId .data-HOMEPAGE.line {
-  stroke: #c22dd5 !important; }
-#reportContainerDivID .data-HOMEPAGE rect,
-#hBarTableDiv .data-HOMEPAGE rect,
-#lineChartTableID .data-HOMEPAGE rect,
-#hBarAppFilterDivId .data-HOMEPAGE rect {
-  fill: #c22dd5 !important;
-  stroke: #c22dd5 !important; }
-#reportContainerDivID .data-HOMEPAGE td span:before,
-#reportContainerDivID .data-HOMEPAGE th span:before,
-#reportContainerDivID .data-HOMEPAGE td:first-child span:before,
-#hBarTableDiv .data-HOMEPAGE td span:before,
-#hBarTableDiv .data-HOMEPAGE th span:before,
-#hBarTableDiv .data-HOMEPAGE td:first-child span:before,
-#lineChartTableID .data-HOMEPAGE td span:before,
-#lineChartTableID .data-HOMEPAGE th span:before,
-#lineChartTableID .data-HOMEPAGE td:first-child span:before,
-#hBarAppFilterDivId .data-HOMEPAGE td span:before,
-#hBarAppFilterDivId .data-HOMEPAGE th span:before,
-#hBarAppFilterDivId .data-HOMEPAGE td:first-child span:before {
-  background-color: #c22dd5 !important; }
-#reportContainerDivID .data-IDEATIONBLOG.line,
-#hBarTableDiv .data-IDEATIONBLOG.line,
-#lineChartTableID .data-IDEATIONBLOG.line,
-#hBarAppFilterDivId .data-IDEATIONBLOG.line {
-  stroke: #db7c00 !important; }
-#reportContainerDivID .data-IDEATIONBLOG rect,
-#hBarTableDiv .data-IDEATIONBLOG rect,
-#lineChartTableID .data-IDEATIONBLOG rect,
-#hBarAppFilterDivId .data-IDEATIONBLOG rect {
-  fill: #db7c00 !important;
-  stroke: #db7c00 !important; }
-#reportContainerDivID .data-IDEATIONBLOG td span:before,
-#reportContainerDivID .data-IDEATIONBLOG th span:before,
-#reportContainerDivID .data-IDEATIONBLOG td:first-child span:before,
-#hBarTableDiv .data-IDEATIONBLOG td span:before,
-#hBarTableDiv .data-IDEATIONBLOG th span:before,
-#hBarTableDiv .data-IDEATIONBLOG td:first-child span:before,
-#lineChartTableID .data-IDEATIONBLOG td span:before,
-#lineChartTableID .data-IDEATIONBLOG th span:before,
-#lineChartTableID .data-IDEATIONBLOG td:first-child span:before,
-#hBarAppFilterDivId .data-IDEATIONBLOG td span:before,
-#hBarAppFilterDivId .data-IDEATIONBLOG th span:before,
-#hBarAppFilterDivId .data-IDEATIONBLOG td:first-child span:before {
-  background-color: #db7c00 !important; }
-#reportContainerDivID .data-PROFILES.line,
-#hBarTableDiv .data-PROFILES.line,
-#lineChartTableID .data-PROFILES.line,
-#hBarAppFilterDivId .data-PROFILES.line {
-  stroke: #188291 !important; }
-#reportContainerDivID .data-PROFILES rect,
-#hBarTableDiv .data-PROFILES rect,
-#lineChartTableID .data-PROFILES rect,
-#hBarAppFilterDivId .data-PROFILES rect {
-  fill: #188291 !important;
-  stroke: #188291 !important; }
-#reportContainerDivID .data-PROFILES td span:before,
-#reportContainerDivID .data-PROFILES th span:before,
-#reportContainerDivID .data-PROFILES td:first-child span:before,
-#hBarTableDiv .data-PROFILES td span:before,
-#hBarTableDiv .data-PROFILES th span:before,
-#hBarTableDiv .data-PROFILES td:first-child span:before,
-#lineChartTableID .data-PROFILES td span:before,
-#lineChartTableID .data-PROFILES th span:before,
-#lineChartTableID .data-PROFILES td:first-child span:before,
-#hBarAppFilterDivId .data-PROFILES td span:before,
-#hBarAppFilterDivId .data-PROFILES th span:before,
-#hBarAppFilterDivId .data-PROFILES td:first-child span:before {
-  background-color: #188291 !important; }
-#reportContainerDivID .data-WIKIS.line,
-#hBarTableDiv .data-WIKIS.line,
-#lineChartTableID .data-WIKIS.line,
-#hBarAppFilterDivId .data-WIKIS.line {
-  stroke: #047cc0 !important; }
-#reportContainerDivID .data-WIKIS rect,
-#hBarTableDiv .data-WIKIS rect,
-#lineChartTableID .data-WIKIS rect,
-#hBarAppFilterDivId .data-WIKIS rect {
-  fill: #047cc0 !important;
-  stroke: #047cc0 !important; }
-#reportContainerDivID .data-WIKIS td span:before,
-#reportContainerDivID .data-WIKIS th span:before,
-#reportContainerDivID .data-WIKIS td:first-child span:before,
-#hBarTableDiv .data-WIKIS td span:before,
-#hBarTableDiv .data-WIKIS th span:before,
-#hBarTableDiv .data-WIKIS td:first-child span:before,
-#lineChartTableID .data-WIKIS td span:before,
-#lineChartTableID .data-WIKIS th span:before,
-#lineChartTableID .data-WIKIS td:first-child span:before,
-#hBarAppFilterDivId .data-WIKIS td span:before,
-#hBarAppFilterDivId .data-WIKIS th span:before,
-#hBarAppFilterDivId .data-WIKIS td:first-child span:before {
-  background-color: #047cc0 !important; }
-
-#hBarChartBodyDivId {
-  border: none !important; }
-
-#moveCirleId {
-  fill: #777677 !important; }
-
-#HorizontalRuleLabelsContain a {
-  color: #000000 !important; }
-
-#reportContainerDivID #statisticHeaderTableID th, #reportContainerDivID #statisticHeaderTableID td {
-  padding-left: 0em !important; }
-
-.appfiltertext,
-.bottomRectText_textBar,
-.gridtable {
+.lfMn.lotusui30dojo .lotusDialogHeader {
+  padding-top: 2rem !important; }
+.lfMn.lotusui30dojo .lotusDialogContent {
+  padding: 0px 20px !important; }
+.lfMn.lotusui30dojo .lfSummaryView .dijitButton.lotusFormButton,
+.lfMn.lotusui30dojo .lfnExt_ViewResponses_Toolbar .dijitButton.lotusFormButton,
+.lfMn.lotusui30dojo .lotusDialogContent .dijitButton.lotusFormButton,
+.lfMn.lotusui30dojo .lotusDialogFooter .dijitButton.lotusFormButton {
   font-family: inherit !important; }
+  .lfMn.lotusui30dojo .lfSummaryView .dijitButton.lotusFormButton:hover,
+  .lfMn.lotusui30dojo .lfnExt_ViewResponses_Toolbar .dijitButton.lotusFormButton:hover,
+  .lfMn.lotusui30dojo .lotusDialogContent .dijitButton.lotusFormButton:hover,
+  .lfMn.lotusui30dojo .lotusDialogFooter .dijitButton.lotusFormButton:hover {
+    transition: color 150ms ease-in, background-color 150ms ease-in, border-color 150ms ease-in !important;
+    border-color: #3C6DF0 !important;
+    background-color: #3C6DF0 !important; }
+    .lfMn.lotusui30dojo .lfSummaryView .dijitButton.lotusFormButton:hover span,
+    .lfMn.lotusui30dojo .lfnExt_ViewResponses_Toolbar .dijitButton.lotusFormButton:hover span,
+    .lfMn.lotusui30dojo .lotusDialogContent .dijitButton.lotusFormButton:hover span,
+    .lfMn.lotusui30dojo .lotusDialogFooter .dijitButton.lotusFormButton:hover span {
+      color: #FFFFFF !important; }
+  .lfMn.lotusui30dojo .lfSummaryView .dijitButton.lotusFormButton.dijitFocused,
+  .lfMn.lotusui30dojo .lfnExt_ViewResponses_Toolbar .dijitButton.lotusFormButton.dijitFocused,
+  .lfMn.lotusui30dojo .lotusDialogContent .dijitButton.lotusFormButton.dijitFocused,
+  .lfMn.lotusui30dojo .lotusDialogFooter .dijitButton.lotusFormButton.dijitFocused {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #969696 !important; }
+  .lfMn.lotusui30dojo .lfSummaryView .dijitButton.lotusFormButton .dijitButtonContents:focus,
+  .lfMn.lotusui30dojo .lfnExt_ViewResponses_Toolbar .dijitButton.lotusFormButton .dijitButtonContents:focus,
+  .lfMn.lotusui30dojo .lotusDialogContent .dijitButton.lotusFormButton .dijitButtonContents:focus,
+  .lfMn.lotusui30dojo .lotusDialogFooter .dijitButton.lotusFormButton .dijitButtonContents:focus {
+    outline: none !important; }
+.lfMn.lotusui30dojo .lfDialogContent .dijitCheckBox {
+  width: 17px !important; }
+.lfMn.lotusui30dojo div[id^="freedom_widget_solution_environment_OptionsList"] .dijitCheckBox {
+  margin-right: 3px; }
+.lfMn.lotusui30dojo .input-cell .dijitTextBox {
+  line-height: 1.5 !important;
+  padding: 0 !important;
+  background: none !important;
+  border: none !important;
+  border-bottom: 1px solid #d8d8d8 !important;
+  font-size: 12.8px !important;
+  padding-right: 1rem !important;
+  padding-bottom: .375rem !important;
+  box-sizing: border-box !important;
+  height: auto !important;
+  height: auto !important; }
+  .lfMn.lotusui30dojo .input-cell .dijitTextBox:focus, .lfMn.lotusui30dojo .input-cell .dijitTextBox .dijitTextBoxFocused {
+    outline: none !important;
+    border-color: #3C6DF0 !important;
+    box-shadow: 0 1px 0 #3C6DF0 !important; }
+.lfMn.lotusui30dojo .secondary-action .dijitDropDownButtonHover .dijitButtonNode .dijitButtonText {
+  text-decoration: none !important; }
+.lfMn.lotusui30dojo .dijitDropDownButton .dijitButtonNode {
+  font-size: 12px !important;
+  font-weight: 500 !important; }
+  .lfMn.lotusui30dojo .dijitDropDownButton .dijitButtonNode .dijitButtonText {
+    color: #000000 !important;
+    text-align: left !important;
+    min-width: 8.5em !important; }
+.lfMn.lotusui30dojo .lfAdvancedSearchConditionsWrapperContainer {
+  padding-left: 0; }
+.lfMn.lotusui30dojo .framed-wrapper,
+.lfMn.lotusui30dojo .hovered-wrapper,
+.lfMn.lotusui30dojo .selected-wrapper {
+  border: none;
+  background-color: #FFFFFF !important;
+  padding-left: 0px !important; }
+.lfMn.lotusui30dojo .dijitArrowButtonInner {
+  background-image: url("data:image/svg+xml;charset=utf8,%3Csvg xmlns=%22http://www.w3.org/2000/svg%22 version=%221.1%22 x=%220px%22 y=%220px%22 viewBox=%220 0 12 7.5%22%3E%3Cpath fill=%22%23595859%22 d=%22M10.6,0L6,4.7L1.4,0L0,1.4l6,6.1l6-6.1L10.6,0z%22/%3E%3C/svg%3E") !important;
+  background-position: 100% 5px !important;
+  background-size: 0.75rem;
+  background-repeat: no-repeat !important; }
+.lfMn.lotusui30dojo .dijitButtonContents {
+  outline: none !important; }
+.lfMn.lotusui30dojo .lfAdvancedSearchBody {
+  padding-left: 0px; }
 
-/*# sourceMappingURL=metrics.css.map */
+html.dj_contentbox {
+  overflow: hidden !important; }
+
+#freedom-composer span {
+  outline: none; }
+
+div[id^="freedom_widget_common_environment_StatusDialog"] .statusContent {
+  outline: none; }
+
+/*# sourceMappingURL=surveys.css.map */

--- a/css/wikis.css
+++ b/css/wikis.css
@@ -2787,6 +2787,45 @@ li[id^="com_ibm_social_as_item_comment"] .lotusStreamUpdate .lotusActions ul {
   #activityStream a.lotusDelete img:focus {
     outline: 1px solid #3C6DF0 !important; }
 
+#sametime-tray ul.navsimplelist button {
+  border-radius: 2rem !important;
+  border-width: 1px !important;
+  border-style: solid !important;
+  box-shadow: none !important;
+  transform: translateZ(0) !important;
+  -webkit-font-smoothing: antialiased !important;
+  cursor: pointer !important;
+  -webkit-box-align: center !important;
+  -webkit-box-pack: center !important;
+  text-align: center !important;
+  transition: background-color 150ms ease-in, color 150ms ease-in, border-color 150ms ease-in !important;
+  white-space: nowrap !important;
+  padding: 9px 20px !important;
+  background-image: none !important;
+  margin: 2px 4px 3px 2px !important;
+  background-color: #3C6DF0 !important;
+  border-color: #3C6DF0 !important;
+  color: #FFFFFF !important;
+  font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important; }
+  #sametime-tray ul.navsimplelist button, #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:focus {
+    text-decoration: none !important;
+    font-weight: 500 !important; }
+  #sametime-tray ul.navsimplelist button:hover, #sametime-tray ul.navsimplelist button:active {
+    outline: none; }
+  #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: 0 0 0 1px #FFFFFF, 0 0 0 2px #3C6DF0 !important;
+    outline: none !important; }
+  .dj_a11y #sametime-tray ul.navsimplelist button:focus, .dijit_a11y #sametime-tray ul.navsimplelist button:focus {
+    box-shadow: none !important;
+    outline: 1px solid #3C6DF0 !important;
+    outline-offset: 1px; }
+  #sametime-tray ul.navsimplelist button:active, #sametime-tray ul.navsimplelist button:hover {
+    background-color: #FFFFFF !important;
+    color: #3C6DF0 !important;
+    border-color: #3C6DF0 !important; }
+
 input[type=checkbox] {
   height: 16px !important;
   width: 20px !important;
@@ -4459,7 +4498,7 @@ li.addressFormLi .addressFormField .addressFormInput {
     .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner {
       border-bottom: 1px solid #d8d8d8 !important;
       padding: .75rem 2.75rem .75rem 0 !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
       .profileDataTable .dijitComboBox.lotusIndent10 .dijitInputField.dijitInputContainer .dijitInputInner:focus {
         border-color: #3C6DF0 !important;
         box-shadow: 0 1px 0 #3C6DF0 !important;
@@ -5375,11 +5414,20 @@ div[dojoattachpoint="streamNode"] {
   padding-right: 2rem !important;
   padding-left: 2rem !important; }
 
+.lconnInsertImage.forum .lotusDialogHeader,
+#blogImgTabDlg .lotusDialogHeader,
+#blogsImageTabDiv .lotusDialogHeader {
+  padding-top: 32px !important; }
+
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
   padding-left: 2rem !important;
   padding-top: 1rem !important; }
   .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] + div {
     padding-left: 2rem !important; }
+
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+  border: 2px solid #3C6DF0 !important; }
 
 input.moveCheckBox {
   vertical-align: middle !important; }
@@ -5580,7 +5628,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 .sc .dialogImportList {
   padding-right: 3rem !important;
   padding-left: 3rem !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   .sc .dialogImportList .lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
     margin: 0 !important; }
 .sc .slideDialog,
@@ -6538,39 +6586,49 @@ div[role="tablist"],
             width: calc(100% + 2px);
             height: 0; }
 
-div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top {
+div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top,
+div.question-creator .dijitTabContainer .dijitTabListContainer-top {
   border-bottom: 1px solid #d8d8d8 !important;
   width: auto !important;
   padding: 0 !important; }
-  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
+  div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"],
+  div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] {
     padding-bottom: calc(.375rem + 3px) !important; }
-    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
+    div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent,
+    div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent {
       font-size: 14px !important;
       font-weight: 600 !important;
       margin-left: 1rem !important;
       background-image: none !important;
       border-radius: 2px;
       color: #595859 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent + .dijitTabInner.dijitTabContent {
         margin-left: .5rem !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked {
         position: relative;
         color: #000000 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:hover {
         color: #FFFFFF !important;
         background-color: #3C6DF0 !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent:focus {
         color: #595859 !important;
         background-color: transparent !important;
         border-color: #3C6DF0 !important; }
-      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
+      div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel,
+      div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel {
         color: inherit !important;
         border: none !important;
         text-transform: none !important; }
-        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
+        div.lconn-survey_dialog .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus,
+        div.question-creator .dijitTabContainer .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent span.tabLabel:focus {
           outline: 0 !important; }
-div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter {
+div.lconn-survey_dialog .dijitTabContainer .lotusDialogFooter,
+div.question-creator .dijitTabContainer .lotusDialogFooter {
   padding: 1rem 1rem !important; }
 
 ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
@@ -6716,7 +6774,7 @@ body.blog.admin #pageTabs.lotusNavTabs {
   left: auto !important;
   padding-right: .5rem !important;
   max-width: calc(100% - 58px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 #socialTags #tagsYouAddedView .lotusTags span.lotusRight, #socialTags #tagsList .lotusTags span.lotusRight {
   order: 2; }
   #socialTags #tagsYouAddedView .lotusTags span.lotusRight .lotusDelete img, #socialTags #tagsList .lotusTags span.lotusRight .lotusDelete img {
@@ -6936,7 +6994,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   #lconnTagWidget_tagList > li .lotusRight,
   #lconnTagWidget_tagCloudView > li .lotusRight,
   ul[id*="_tagList"]:not(#tagsDiv_tagList) > li .lotusRight {
@@ -6978,7 +7036,7 @@ ul.lotusRelatedTags a {
   overflow: hidden;
   text-overflow: ellipsis;
   background: #FFFFFF !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
   ul.lotusRelatedTags a a {
     color: #000000 !important;
     font-weight: normal !important; }
@@ -7066,7 +7124,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li {
     left: auto !important;
     padding-right: .5rem !important;
     max-width: calc(100% - 58px) !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
     div[dojoattachpoint="_selectedTagsSection"] .lotusList > li span.lotusLeft a,
     div[data-dojo-attach-point="_selectedTagsSection"] .lotusList > li span.lotusLeft a {
       color: #000000 !important;
@@ -7240,7 +7298,7 @@ input.lotusText.scTagTypeahead {
     height: 100%;
     margin: 0 3px;
     padding: .45rem 0;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     display: inline-block;
     vertical-align: middle; }
     .lotusMain .lotusTags.lotusMeta span[role="listitem"] a[role="button"] img,
@@ -7598,7 +7656,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative; }
   #memberAddFormDiv #memberList .lotusFilter.filterSpacing a,
   #memberInviteFormDiv #memberList .lotusFilter.filterSpacing a, #addMembersWidget #memberList .member a,
@@ -8613,7 +8671,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   border: 1px solid #d8d8d8 !important; }
   body > div[id*="dialogs_deleteConfirm"] * {
     max-width: 100% !important;
-    box-sizing: border-box; }
+    box-sizing: border-box !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusDialog.lotusForm2._lotusDelete {
     border: none !important; }
   body > div[id*="dialogs_deleteConfirm"] .lotusErrorContent {
@@ -8772,7 +8830,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       font-weight: normal !important;
       font-size: 0.875rem;
       width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       overflow: hidden;
       white-space: nowrap;
       text-overflow: ellipsis;
@@ -9840,7 +9898,7 @@ body > div[id*="dialogs_deleteConfirm"] {
         position: absolute;
         top: 0;
         left: 0;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 100%; }
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > .lotusMenuSubsection ul li.lotusSelected a,
       .lotusMain #lotusColLeft:not(.wpthemeNarrow) .lotusSection:not([id*="Tag"]) > div > div ul li.lotusSelected a,
@@ -10063,7 +10121,7 @@ body > div[id*="dialogs_deleteConfirm"] {
     transition: none !important;
     font-weight: normal !important;
     font-size: 0.875rem;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     overflow: visible;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -10118,7 +10176,7 @@ body > div[id*="dialogs_deleteConfirm"] {
       .lotusColLeft div[id^="lconn_share_widget_Tree_"] .headerSelector.lotusSelected::before {
         content: '';
         display: block;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: 4px;
         height: calc( (14px * 2) + calc(14px * 1.5) );
         position: absolute;
@@ -10161,7 +10219,7 @@ body > div[id*="dialogs_deleteConfirm"] {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: calc(100% - 40px) !important;
-  box-sizing: border-box; }
+  box-sizing: border-box !important; }
 
 .lotusMain #lotusColLeft #mainActions {
   padding: 14px 24px;
@@ -11007,7 +11065,7 @@ input[id^="lconn_wikis_widget_MembershipOptions"] {
     .dijitLayoutContainer.dijitDialog .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"].lotusDialogHeader {
       position: relative !important;
       width: 100% !important;
-      box-sizing: border-box; }
+      box-sizing: border-box !important; }
 
 .lconnWikisMembersSummary {
   margin-left: 40px !important; }

--- a/docs/support.html
+++ b/docs/support.html
@@ -35,7 +35,8 @@
   <ul>
     <li>CONTENTS</li>
     <li><a href="#faq">FAQ</a></li>
-    <li><a href="#supported">What is supported</a></li>
+    <li><a href="#supported">Apps supported</a></li>
+    <li><a href="#browsers">Browsers support</a></li>
     <li><a href="#getsupport">Getting support</a></li>
     <li><a href="./index.html">&#8592; Back to Main</a></li>
   </ul>
@@ -73,12 +74,21 @@
 
 <p>The App Registry includes the Visual Update 1 for IBM Connections application. A company adds an extension to the App Registry, to override styles, and it is called "Xtended Company Theme". The Visual Update 1 for IBM Connections application is loaded and applied first. Next the "Xtended Company Theme" gets loaded with its CSS and/or JS overriding any of the Visual Update 1 for IBM Connections changes.</p>
 
-<h2><a class="anchor" name="supported">What is supported</a></h2>
+<!--apps supported-->
+<h2><a class="anchor" name="supported">Apps supported</a></h2>
 <p>Visual Update 1 for IBM Connections is supported only when the application files are installed and configured as-is, with no change and in which all the following criteria are met: (1) Only the Hakari or Verse Theme (Default) is enabled; (2) No additional customizations are configured. Implementations added manually through an organization extension, combined with additional customizations, and/or contained code which was modified from its original state will not receive support considerations.</p>
 
 <p>Because this application is a customization on top of Connections, PMRs will not be accepted and resolved by IBM. Questions and support requests will be directed to be posted in the support forum located <a href="https://developer.ibm.com/answers/topics/cnx-custom-theme.html">here</a>. The application provider will monitor the forum and address issues as appropriate in subsequent updates to the application files. IBM will not assist with making custom modifications to the open source code provided for this application nor modifications created to add additional customizations in lieu of the Visual Update 1 for Connections.</p>
 
 <p>Bi directional language support is not included in this release. Visual updates applies only to applications stated in official communications and will not extend to custom widgets added to Connections. IBM plans to regularly add improvements to the visual update and will share communications accordingly.</p>
+
+<!--Browsers supported-->
+<h2><a class="anchor" name="browsers">Browsers supported</a></h2>
+<p>Our goal is to support the <a href="http://www-01.ibm.com/support/docview.wss?uid=swg22017033" target="_blank">same browsers Connections supports</a>.</p>
+
+<p>However, due to limited resources and the 'as-is' nature of this application, we have not completed thorough cross-browser testing. We test every update on Chrome. We have completed rounds of testing on Firefox, Safari, and Microsoft Internet Explorer 11. Otherwise, we rely on user feedback to identify issues.</p>
+
+<p>If an issue is found for a particular browser, let us know and we will do our best to fix the issue. To report an issue, see the next section on Getting Support.</p>
 
 <!--Getting support-->
 <h2><a class="anchor" name="getsupport">Getting support</a></h2>

--- a/scss/apps/activities/_activities.scss
+++ b/scss/apps/activities/_activities.scss
@@ -133,7 +133,7 @@ body.scloud3 .lotusHeader #actViewLabel h1 {
 
   > .lotusRightCorner {
     padding: 0 !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     min-width: 0 !important;
 
     > .lotusInner {
@@ -148,7 +148,7 @@ body.scloud3 .lotusHeader #actViewLabel h1 {
   }
   padding-left: 48px;
   margin-left: $leftnav-width;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   width: calc(100% - #{$leftnav-width});
   h2#lotusPlaceBar-Title {
     @include font-size($title...);

--- a/scss/apps/activities/_leftNav.scss
+++ b/scss/apps/activities/_leftNav.scss
@@ -5,7 +5,7 @@
     position:relative!important;
     top:-15px!important;
     margin-left:0px!important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     .lotusMenu {
       width: $leftnav-width;
       position:relative!important;
@@ -53,7 +53,7 @@
           margin: 0px 0px;
           a {
             @include font-size($bodylink...);
-            box-sizing: border-box;
+            box-sizing: border-box !important;
             margin: 0px 0px !important;
             padding: $leftnav-vertical-padding $leftnav-horizontal-padding !important;
             padding-left: calc(#{$leftnav-indent-padding} + #{$leftnav-horizontal-padding}) !important;

--- a/scss/apps/communities/_dialogs.scss
+++ b/scss/apps/communities/_dialogs.scss
@@ -37,7 +37,7 @@ body > div[id*="dialogs_deleteConfirm"] {
 
   * {
     max-width: 100% !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
   }
 
   .lotusDialog.lotusForm2._lotusDelete {

--- a/scss/apps/communities/_leftnav.scss
+++ b/scss/apps/communities/_leftnav.scss
@@ -63,7 +63,7 @@
         font-weight: normal !important;
         font-size: $body-sm-font-size;
         width: 100% !important;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         overflow: hidden;
         white-space: nowrap;
         text-overflow: ellipsis;
@@ -291,7 +291,7 @@
           position: absolute;
           top: 0;
           left: 0;
-          box-sizing: border-box;
+          box-sizing: border-box !important;
           width: 100%;
         }
         &.lotusSelected a {
@@ -437,7 +437,7 @@
     transition:none!important;
     font-weight: normal !important;
     font-size: $body-sm-font-size;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     overflow: visible;
     white-space: nowrap;
     text-overflow: ellipsis;
@@ -466,7 +466,7 @@
       &::before {
         content: '';
         display: block;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         width: $leftnav-active-border-thickness;
         height: $leftnav-line-item-height;
         position: absolute;
@@ -530,7 +530,7 @@
       text-overflow: ellipsis;
       white-space: nowrap;
       max-width: calc(100% - 40px) !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
 }

--- a/scss/apps/communities/blogs/_upload.scss
+++ b/scss/apps/communities/blogs/_upload.scss
@@ -19,3 +19,8 @@ fieldset.blogsHiddenBorder{
   margin-left:0;
   padding-left:0;
 }
+
+//2236: Blog: Change the selected border color of image layout
+.lconnInsertImage input.blogImgLayout.lotusSelected {
+  border: 2px solid $border-selected !important;
+}

--- a/scss/apps/files/_leftNav.scss
+++ b/scss/apps/files/_leftNav.scss
@@ -123,6 +123,11 @@ html.lconnFiles.files-enable-simplify-left-nav {
         }
       }
 
+      //Fix for when onprem Action Center is enabled 2207
+      .myDriveNavigation .lotusInner {
+        box-sizing: content-box;
+      }
+
       //Update indent of folders
       #menu_myfolders_childContainer {
         margin-left: 32px !important;
@@ -389,7 +394,7 @@ html.lconnFiles.files-enable-simplify-left-nav {
       text-overflow: ellipsis;
       white-space: nowrap;
       max-width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       float: none !important;
     }
   }

--- a/scss/apps/files/_spacing.scss
+++ b/scss/apps/files/_spacing.scss
@@ -80,6 +80,7 @@ html.lconnFiles.files-enable-simplify-left-nav {
       //Left side of toolbar: folder and filter panel switcher
       .toolActions {
         width: 182px;
+        box-sizing: content-box !important;
         //Panel icon selection and focus
         .actionOn:after {
           border-bottom: 3px solid $border-selected;
@@ -269,6 +270,7 @@ div.filesListFilled #scene-body {
       top: 0 !important;
       .lotusCheckbox {
         padding-top: 6px;
+        margin-top: 2px;
       }
     }
   }

--- a/scss/apps/home/_classic.scss
+++ b/scss/apps/home/_classic.scss
@@ -162,6 +162,43 @@
           padding:10px 6px 0px 6px !important;
         }
       }
+      // survey icons 2139
+      img[src$="survey_draft_32.png"] {
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        width: 32px;
+        height: 32px;
+        background-image: svg-url-with-replaced-fill($svg-survey-draft, '#000000', $icon-default) !important;
+        background-size: 32px 32px;
+        background-position: 0 0 !important;
+        background-repeat: no-repeat !important;
+        margin-top: 4px !important;
+        padding-left: 32px;
+      }
+      img[src$="survey_incomplete_32.png"] {
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        width: 32px;
+        height: 32px;
+        background-image: svg-url-with-replaced-fill($svg-survey-incomplete, '#000000', $icon-default) !important;
+        background-size: 32px 32px;
+        background-position: 0 0 !important;
+        background-repeat: no-repeat !important;
+        margin-top: 4px !important;
+        padding-left: 32px;
+      }
+      img[src$="survey_complete_32.png"] {
+        -moz-box-sizing: border-box;
+        box-sizing: border-box;
+        width: 32px;
+        height: 32px;
+        background-image: svg-url-with-replaced-fill($svg-survey-complete, '#000000', $icon-default) !important;
+        background-size: 32px 32px;
+        background-position: 0 0 !important;
+        background-repeat: no-repeat !important;
+        margin-top: 4px !important;
+        padding-left: 32px;
+      }
     }
   }
 }

--- a/scss/apps/profiles/_contactcards.scss
+++ b/scss/apps/profiles/_contactcards.scss
@@ -37,7 +37,7 @@ div[class$="directory"] {
   > a {
     padding: .5rem !important;
     margin: 0 !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     font-weight: normal !important;
     @media only screen and (min-width: 0px) {
       width: 50% !important;
@@ -86,7 +86,7 @@ div[class$="directory"] {
       display: flex;
       flex-direction: row;
       padding: 1.5rem 3.5rem 1.5rem 1.5rem;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       position: relative;
 
       .lotusFloatContent,
@@ -156,7 +156,7 @@ div[class$="directory"] {
             margin: 0 auto 10px !important;
             padding: 0 !important;
             display: inline-block;
-            box-sizing: border-box;
+            box-sizing: border-box !important;
             width: 20px !important;
             height: 20px !important;
 

--- a/scss/apps/profiles/_directorysearch.scss
+++ b/scss/apps/profiles/_directorysearch.scss
@@ -26,7 +26,7 @@
 
       .lconn_personContainer {
         border: 2px solid transparent;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
         box-shadow: 0px 2px 5px $box-shadow-30;
         padding: 1.5rem 3.5rem 1.5rem 1.5rem;
         margin: .5rem !important;

--- a/scss/apps/profiles/_metaSpacingLayout.scss
+++ b/scss/apps/profiles/_metaSpacingLayout.scss
@@ -4,7 +4,7 @@
 #profilePaneRight {
   width: 300px;
   margin-left: 3.25rem;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
 }
 .lotusWidget2 {
   margin-bottom: 3rem !important;

--- a/scss/apps/profiles/_network.scss
+++ b/scss/apps/profiles/_network.scss
@@ -32,7 +32,7 @@
   .lotusNetworkPerson {
     padding: 1rem 3px 0 !important;
     width: 33%;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     text-align: center;
     position: relative;
     .vcard {

--- a/scss/apps/search/_leftNav.scss
+++ b/scss/apps/search/_leftNav.scss
@@ -3,7 +3,7 @@
     position:relative!important;
     top:-15px!important;
     margin-left:0px!important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     .lotusMenu{
       width: $leftnav-width;
       position:relative!important;

--- a/scss/apps/settings/_leftnav.scss
+++ b/scss/apps/settings/_leftnav.scss
@@ -32,7 +32,7 @@
           display: block;
           border: none !important;
           transition:$leftnav-border-slide!important;
-          box-sizing: border-box;
+          box-sizing: border-box !important;
           font-weight: normal !important;
           &:hover {
             background-color:$background-side-hover !important;

--- a/scss/apps/surveys/_surveys.scss
+++ b/scss/apps/surveys/_surveys.scss
@@ -1,0 +1,218 @@
+// Surveys Settings
+// Add a question dialog
+div[id^="freedom_widget_ide_environment_QuestionCreatorDialog"] {
+  top: -30px !important;
+  .dijitTabContainer {
+    .dijitTabListContainer-top {
+      height: 68px !important;
+      .dijitTabListWrapper {
+        height: auto !important;
+      }
+      div[role="tablist"] {
+        padding-bottom: calc(.375rem + 3px) !important;
+        .dijitTab {
+          padding: 0.625rem 0 0.375rem 0 !important;
+          margin: 0 0 0 1rem !important;
+          border-bottom: none !important;
+          &.dijitTabChecked {
+            border-bottom: 4px solid $tab-border-selected !important;
+          }
+          .dijitTabInner.dijitTabContent {
+            margin-left: 0 !important;
+            span {
+              padding: 0.5rem 1rem !important;
+              color: $tab-text !important;
+              border: 1px solid transparent !important;
+              @include font-size($tabs...);
+              &:focus {
+                text-decoration: none !important;
+                border-color: $tab-border-focus !important;
+                color: $tab-text !important;
+             }
+             &:hover {
+                border-color: $tab-border-focus !important;
+                background-color: $tab-background-hover !important;
+                color: $tab-text-hover !important;
+              }
+            }
+          }
+        }
+      }
+    }
+    .lotusMessage {
+      img {
+        margin-top: 12px !important;
+      }
+      span {
+      font-size: 1.3em !important;
+      }
+    }
+  }
+  .lotusDialogFooter {
+    span.dijitButton.lotusFormButton {
+      .dijitButtonText {
+        font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+      }
+      &.dijitButtonHover {
+        background-color: $btn-secondary-fill-hover !important;
+        border-color: $btn-secondary-outline-hover !important;
+        .dijitButtonText {
+          color: $btn-secondary-text-hover !important;
+        }
+      }
+      &.dijitButtonFocused {
+        box-shadow: 0 0 0 1px $btn-primary-text-disabled, 0 0 0 2px $btn-primary-outline-disabled !important;
+      }
+    }
+    .dijitButtonContents {
+      outline: none !important;
+    }
+  }
+}
+// START Summary - Responses Tabs ==========
+.lfSummaryWrapper {
+  div.dijitVisible {
+    top: 24px !important;
+    .dijitContentPane {
+      top: 0 !important;
+      left: 0 !important;
+      padding-top: 8px !important;
+      padding-bottom: 8px !important;
+      &.lfOverviewToolbar {
+        padding: 0 !important;
+      }
+    }
+  }
+  .lfViewResponseControls {
+    border-bottom: none !important;
+    .lotusInlinelist {
+      height: 54px !important;
+      bottom: 0 !important;
+    }
+    ul[role="tablist"] {
+      li {
+        padding: 0.625rem 0 0.375rem 0 !important;
+        margin: 0 0 0 1rem !important;
+        border-bottom: none !important;
+        &.active {
+          border-bottom: 4px solid $tab-border-selected !important;
+          }
+        &:focus {
+          outline: none !important;
+        }
+        a {
+          padding: 0.5rem 1rem !important;
+          color: $tab-text !important;
+          border: 1px solid transparent !important;
+          @include font-size($tabs...);
+          &:focus {
+            text-decoration: none !important;
+            border-color: $tab-border-focus !important;
+          }
+          &:hover {
+            border-color: $tab-border-focus !important;
+            background-color: $tab-background-hover !important;
+            color: $tab-text-hover !important;
+          }
+        }
+      }
+    }
+  }
+}
+// END Summary - Responses Tabs ==========
+
+//2219 Start style survey dialogs and buttons
+.lfMn.lotusui30dojo {
+  .lotusDialogHeader {
+    padding-top: 2rem !important;
+  }
+  .lotusDialogContent {
+    padding: 0px 20px !important;
+  }
+  .lfSummaryView,
+  .lfnExt_ViewResponses_Toolbar,
+  .lotusDialogContent,
+  .lotusDialogFooter {
+    .dijitButton.lotusFormButton {
+      font-family: inherit !important;
+      &:hover {
+        transition: color 150ms ease-in, background-color 150ms ease-in, border-color 150ms ease-in !important;
+        border-color: $btn-secondary-outline-hover !important;
+        background-color: $btn-secondary-fill-hover !important;
+        span {
+          color: $btn-secondary-text-hover !important;
+        }
+      }
+      &.dijitFocused {
+        box-shadow: 0 0 0 1px $btn-primary-text-disabled, 0 0 0 2px $btn-primary-outline-disabled !important;
+      }
+      .dijitButtonContents {
+        &:focus {
+          outline: none !important;
+        }
+      }
+    }
+  }
+  .lfDialogContent {
+    .dijitCheckBox {
+      width: 17px !important;
+    }
+  }
+  div[id^="freedom_widget_solution_environment_OptionsList"] .dijitCheckBox {
+    margin-right: 3px;
+  }
+  .input-cell .dijitTextBox {
+    @include textinput;
+    height:auto !important;
+  }
+  .secondary-action .dijitDropDownButtonHover .dijitButtonNode .dijitButtonText {
+      text-decoration: none !important;
+    }
+  .dijitDropDownButton .dijitButtonNode {
+    @include font-size($caption...);
+    .dijitButtonText {
+      color: $color-black !important;
+      text-align: left !important;
+      min-width: 8.5em !important;
+    }
+  }
+  .lfAdvancedSearchConditionsWrapperContainer {
+    padding-left: 0;
+  }
+  .framed-wrapper,
+  .hovered-wrapper,
+  .selected-wrapper {
+    border: none;
+    background-color: $color-white !important;
+    padding-left: 0px !important;
+  }
+  .dijitArrowButtonInner {
+    background-image: svg-url-with-replaced-fill($svg-chevron-down, '#000000', $icon-default) !important;
+    background-position:100% 5px!important;
+    background-size:0.75rem;
+    background-repeat: no-repeat !important;
+  }
+  .dijitButtonContents {
+    outline: none !important;
+  }
+  .lfAdvancedSearchBody {
+    padding-left: 0px;
+  }
+}
+//2219 End style survey dialogs and buttons
+
+// Featured survey width issue 1154
+html.dj_contentbox {
+  overflow: hidden !important;
+}
+// Compose question - no default focus on span text fields
+#freedom-composer {
+  span {
+    outline: none;
+  }
+}
+
+//2259 Survey error popup
+div[id^="freedom_widget_common_environment_StatusDialog"] .statusContent {
+  outline: none;
+}

--- a/scss/apps/wikis/_wikis.scss
+++ b/scss/apps/wikis/_wikis.scss
@@ -19,7 +19,7 @@ input[id^="lconn_wikis_widget_MembershipOptions"] {
     > .lotusDialog > div[id^="lconn_share"].lotusDialogHeader {
       position: relative !important;
       width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
 }

--- a/scss/components/_buttons.scss
+++ b/scss/components/_buttons.scss
@@ -514,3 +514,11 @@ li[id^="com_ibm_social_as_item_comment"] {
     @include bx--modal-close;
   }
 }
+
+// Sametime login / logout button
+#sametime-tray ul.navsimplelist button {
+  @include btnprimary;
+	font-family: 'IBM Plex Sans', 'IBM Helvetica', 'Helvetica Neue', HelveticaNeue, Helvetica, sans-serif;
+  padding: 0 20px !important;
+  margin-top: 12px !important;
+}

--- a/scss/components/_form.scss
+++ b/scss/components/_form.scss
@@ -205,7 +205,7 @@ li.addressFormLi {
 			//font-size: $body-font-size !important;
 			border-bottom: 1px solid $color-gray-10 !important;
 			padding: .75rem 2.75rem .75rem 0 !important;
-			box-sizing: border-box;
+			box-sizing: border-box !important;
 
 			&:focus {
 				border-color: $border-field-focus !important;

--- a/scss/components/_modal.scss
+++ b/scss/components/_modal.scss
@@ -151,6 +151,16 @@ div[dojoattachpoint="streamNode"] {
 	padding-left:2rem!important;
 }
 
+
+//2238: Blog and Forum: The top spacing is too large, it should be 32px.
+.lconnInsertImage.forum,
+#blogImgTabDlg,
+#blogsImageTabDiv {
+	.lotusDialogHeader {
+		padding-top: 32px !important;
+	}
+}
+
 // fix for right col too wide in Wiki Move Page dlg
 .lotusDialogBorder > .lotusDialog > div[id^="lconn_share"] {
 	padding-left:2rem!important;
@@ -158,6 +168,12 @@ div[dojoattachpoint="streamNode"] {
 	+ div {
 		padding-left:2rem!important;
 	}
+}
+
+//2240: Wiki and blog insert image, Existing Imges selected border color.
+.images .uploadedImageTd.imageSelected .insertImage,
+.lconnInsertImage .uploadedImageTd .insertImage.lotusSelected {
+    border: 2px solid $border-selected !important;
 }
 
 // Move page checkbox alignment
@@ -398,7 +414,7 @@ div[id^="lconn_share"][id*="widget_Dialog"] .lotusDialog .lotusDialogContent .lo
 	.dialogImportList {
 		padding-right:3rem!important;
 		padding-left:3rem!important;
-		box-sizing: border-box;
+		box-sizing: border-box !important;
 
 		.lotusStream .lotusPaging .lotusInlinelist .lotusFirst {
 			margin: 0 !important;

--- a/scss/components/_tabs.scss
+++ b/scss/components/_tabs.scss
@@ -348,7 +348,8 @@ div[role="tablist"],
 }
 
 // Survey settings dialog
-div.lconn-survey_dialog .dijitTabContainer {
+div.lconn-survey_dialog .dijitTabContainer,
+div.question-creator .dijitTabContainer {
   .dijitTabListContainer-top {
     border-bottom: 1px solid $border-separator !important;
     width: auto !important;
@@ -433,7 +434,7 @@ ul[id^="lconn_tabsWidget"][id$="_CenterTabsUL"] {
 }
 body.blog.admin #pageTabs.lotusNavTabs {
   border-bottom: 1px solid $border-separator;
-  
+
   li {
     float: none;
     display: inline-block;
@@ -470,11 +471,11 @@ body.blog.admin #pageTabs.lotusNavTabs {
   margin-top: 1.75rem;
 }
 
-// insert img new ui 
+// insert img new ui
 .lotusui30dojo .lconnInsertImage.forum .lotusDialog {
   .dijitTabListContainer-top.dijitTabController {
     margin-right: 0;
-    
+
     ~ .dijitTabPaneWrapper {
       padding: 0;
     }
@@ -484,14 +485,14 @@ body.blog.admin #pageTabs.lotusNavTabs {
   }
 }
 
-// 1747 rich content widget tabs 
+// 1747 rich content widget tabs
 .lotusCommunities .lotusWidget2 .lotusTabs {
   #qkrRefHide + li {
     margin-left: 0 !important;
   }
   a:not([role="tab"]) {
     color: $tab-text !important;
-    
+
     &:focus {
       color: $tab-text-focus !important;
     }

--- a/scss/components/_tags.scss
+++ b/scss/components/_tags.scss
@@ -60,7 +60,7 @@
         left: auto !important;
         padding-right: .5rem !important;
         max-width: calc(100% - 58px) !important;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
       }
       span.lotusRight {
         order: 2;
@@ -219,7 +219,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) {
       left: auto !important;
       padding-right: .5rem !important;
       max-width: calc(100% - 58px) !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
     .lotusRight {
       border-top-left-radius: 0 !important;
@@ -246,7 +246,7 @@ ul[id*="_tagList"]:not(#tagsDiv_tagList) {
 // related tags in the left menu:
 ul.lotusRelatedTags a {
   @include tags(white);
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   wbr {
     display: none !important;
   }
@@ -282,7 +282,7 @@ div[data-dojo-attach-point="_selectedTagsSection"] {
         left: auto !important;
         padding-right: .5rem !important;
         max-width: calc(100% - 58px) !important;
-        box-sizing: border-box;
+        box-sizing: border-box !important;
       }
       a.lotusDelete {
         order: 2;
@@ -425,7 +425,7 @@ input.lotusText.scTagTypeahead {
       height: 100%;
       margin: 0 3px;
       padding: .45rem 0;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
       display: inline-block;
       vertical-align: middle;
       img{
@@ -611,7 +611,7 @@ input.lotusText.scTagTypeahead {
   padding-right: 1.5rem !important;
   float: left;
   margin-bottom: .5rem !important;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   position: relative;
 
   img.lotusDelete {

--- a/scss/global/_fileTypeIcons.scss
+++ b/scss/global/_fileTypeIcons.scss
@@ -54,7 +54,7 @@ img[class*="Calendar"] {
   width: 16px;
   height: 16px;
   padding: 16px 16px 0 0;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
 }
 .ics-viewer-title{
   .lconn-ftype16, .iconsFileTypes16{
@@ -82,7 +82,7 @@ img[class*="Calendar"] {
   width: 32px;
   height: 32px;
   padding-left: 32px;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   background-repeat: no-repeat;
 }
 .lconn-ftype64, .iconsFileTypes64{
@@ -96,7 +96,7 @@ img[class*="Calendar"] {
   width: 32px;
   height: 32px;
   padding: 32px 32px 0 0;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
 }
 .lconn-ftype16-docx,
 .lconn-ftype16-xlsx,
@@ -106,7 +106,7 @@ img[class*="Calendar"] {
   width: 16px;
   height: 16px;
   padding: 16px 16px 0 0;
-  box-sizing: border-box;
+  box-sizing: border-box !important;
 }
 
 img[class*="ftype"],
@@ -272,7 +272,7 @@ img[class$="json"],
 img[class$="scss"],
 img[class$="xml"],
 img[class*="Code"],
-span[class$="css"],
+span[class$="css"]:not(.freedom-base-mixin-css),
 span[class$="dmg"],
 span[class$="exe"],
 span[class$="html"]:not(.cke_dialog_ui_html),

--- a/scss/global/_global.scss
+++ b/scss/global/_global.scss
@@ -8,6 +8,7 @@
 @import "responsive";
 @import "searchButton";
 @import "searchHistory";
+@import "sharebox_onprem";
 
 /////////////CUSTOMIZE IN EXTENSIONS////////////
 @import "../extensions/global/global";

--- a/scss/global/_navbar.scss
+++ b/scss/global/_navbar.scss
@@ -17,7 +17,7 @@
     position: absolute;
     top: -$navbar-height;
   }
-  box-sizing: border-box;
+  box-sizing: border-box !important;
 
   //Text on the navbar
   &>div.navmenu, &>a { //Words on navbar directly inside .ics-scbanner

--- a/scss/global/_responsive.scss
+++ b/scss/global/_responsive.scss
@@ -21,7 +21,7 @@ body.meetingBody:not(.cke_editable),
 .lotusui30 .lotusFooter,
 #lotusFrame #lotusFooter.lotusFooter,
 .lotusFrame #lotusFooter.lotusFooter {
-  box-sizing: border-box;
+  box-sizing: border-box !important;
   margin-left: 0 !important;
   margin-right: 0 !important;
   max-width: 100%;
@@ -42,7 +42,7 @@ body.meetingBody:not(.cke_editable),
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout #lotusMain[role="tabpanel"],
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout #lotusMain[role="tabpanel"] {
     padding-left: 40px !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
   }
 }
 @media screen and (max-width: 1060px) {
@@ -70,12 +70,12 @@ body.meetingBody:not(.cke_editable),
     #lotusContent.wpthemeWide {
       width: 100% !important;
       min-width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
     #lotusColLeft ~ #lotusContent.wpthemeWide {
       width: calc(100% - #{$leftnav-width}) !important;
       min-width: calc(100% - #{$leftnav-width}) !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
     #lotusColLeft ~ .lotusColRight:not([style^="display: none;"]) ~ #lotusContent.wpthemeWide {
       width: calc(100% - 475px) !important;
@@ -89,13 +89,13 @@ body.meetingBody:not(.cke_editable),
     .lotusColRight {
       width: 200px !important;
       min-width: 200px !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
     + #lotusContent {
       width: calc(100% - 488px) !important;
       min-width: calc(100% - 488px) !important;
       float: right;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
   // profile page
@@ -104,13 +104,13 @@ body.meetingBody:not(.cke_editable),
     width: calc(100% - 505px) !important;
     min-width: calc(100% - 505px) !important;
     float: right;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
   }
   #profilePaneRight,
   .activityStreamPage #lotusColRight {
     width: 150px !important;
     min-width: 150px !important;
-    box-sizing: border-box;
+    box-sizing: border-box !important;
     margin-left: 2.45rem !important;
 
     #recent-friends-container .lotusChunk .lotusNetworkPerson {
@@ -134,7 +134,7 @@ body.meetingBody:not(.cke_editable),
 
     #joinUrl {
       width: 100% !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
 
     .verseColsRight {
@@ -159,7 +159,7 @@ body.meetingBody:not(.cke_editable),
     margin-left: $leftnav-width !important;
 
     #lotusContent {
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
   .lotusWidget_3columnLayoutWithBanner .lotusColLeft.wpthemeThin ~ #lotusMainColumns {
@@ -192,7 +192,7 @@ body.meetingBody:not(.cke_editable),
 // communities responsive breakpoint:
 @media (max-width: 899px) {
   #lotusMain {
-    box-sizing: border-box;
+    box-sizing: border-box !important;
   }
   .lotusui30_body .lotusWidget_3columnsTopMenuLayout,
   .lotusui30_body .lotusWidget_3columnsWithBannerTopMenuLayout {
@@ -243,7 +243,7 @@ body.meetingBody:not(.cke_editable),
       max-width: calc(50% - 15px);
       vertical-align: top;
       display: inline-block !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
 
@@ -256,7 +256,7 @@ body.meetingBody:not(.cke_editable),
     #lotusColRight.lotusColRight.wpthemeNarrow.wpthemeNarrowPlus {
       width: 100% !important;
       max-width: 100%;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
 }
@@ -279,7 +279,7 @@ body.meetingBody:not(.cke_editable),
       max-width: calc(33% - 15px);
       vertical-align: top;
       display: inline-block !important;
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
 
@@ -291,7 +291,7 @@ body.meetingBody:not(.cke_editable),
     #lotusColRight.lotusColRight.wpthemeNarrow.wpthemeNarrowPlus {
       width: calc(50% - 16px) !important;
       max-width: calc(50% - 16px);
-      box-sizing: border-box;
+      box-sizing: border-box !important;
     }
   }
   .lotusWidget_3columnsTopMenuLayout #contentArea,
@@ -347,4 +347,9 @@ div[id^="lconn_communities_catalog_widgets_ResultsDisplayWidget_"] {
   .lotusui30_layout & .lotusColLeft:after {
     border-right-width: 264px !important;
   }
+}
+
+// Disable minwidth on meetings iframe - issue 2141
+.lotusui30_body.scloud3.tundra:not(.compactMode):not(.concord) {
+  min-width: 0 !important;
 }

--- a/scss/global/_searchButton.scss
+++ b/scss/global/_searchButton.scss
@@ -1,15 +1,27 @@
 //Floating search button
 
 //Position search button relative to navbar
-#lotusFrame .tabNavBar {
-  &:not(.tabNavFixed) {
-    .icSearchPaneButton {
+#lotusFrame #lotusTitleBar,
+#lotusFrame .lotusTitleBar2,
+.lotusFrame #lotusTitleBar,
+.lotusFrame .lotusTitleBar {
+  //Most pages where search button appears; Orient Me and Files works with no change
+  .lotusInner {
+    div.icSearchPaneButton {
       top: calc(#{$navbar-height} + 20px) !important; //Position search button relative to navbar height
     }
   }
-  &.tabNavFixed {
-    .icSearchPaneButton {
-      top: 20px !important; //Position search button when navbar is hidden on scroll
+  //Community top navigation
+  .tabNavBar {
+    &:not(.tabNavFixed) {
+      .icSearchPaneButton {
+        top: calc(#{$navbar-height} + 20px) !important; //Position search button relative to navbar height
+      }
+    }
+    &.tabNavFixed {
+      .icSearchPaneButton {
+        top: 20px !important; //Position search button when navbar is hidden on scroll
+      }
     }
   }
 }
@@ -61,7 +73,17 @@
   }
 }
 
-//Search panel open
+//Onprem, override box-sizing to fix issue if Action Center is enabled
+.icSearchPane,
+.icSearchPane * {
+  box-sizing: border-box !important;
+}
+
+//Position Search pane below navigation bar
+.icSearchPane {
+  top: calc(#{$navbar-height} + 1px) !important;
+}
+
 //Search field on history panel
 .icSearchBar{
   a.icSearchIcon {

--- a/scss/global/_sharebox_onprem.scss
+++ b/scss/global/_sharebox_onprem.scss
@@ -1,0 +1,153 @@
+// onprem ShareBoxGadget DIALOGS
+body.lotusui30_body .uploadFileGadgetDiv {
+  width: 500px !important;
+  fieldset[id="lconn_files_widget_UploadFile_0_share_with_fieldset"] {
+    min-width: 380px !important;
+  }
+}
+body.lconnShareboxGadget {
+  min-width: 500px !important;
+  max-width: 100%;
+}
+//Set right and left side of sharebox
+.lotusui30dojo .lcSharebox div.dijitDialogTitleBar,
+.lcSharebox .dijitTabContainer {
+  padding-right: 2rem !important;
+  padding-left: 2rem !important;
+  margin-left: 0 !important;
+}
+.lotusui30dojo .lcSharebox div.dijitDialogTitleBar {
+  box-shadow: none !important;
+}
+//Set bottom of sharebox
+.lotusDialogHeader.shareBoxBottomHeader {
+	padding-top: 0 !important;
+}
+
+//Sharebox Status Update tab
+body.lconnShareboxGadget {
+  input[type="button"][dojoattachpoint="postButtonNode"],
+  input[type="button"][dojoattachpoint="resetButtonNode"],
+   {
+    &.lotusBtnDisabled {
+      @include btnsecondary;
+    }
+    @include btnprimary;
+  }
+  select {
+    @include select;
+    min-width: 45% !important;
+  }
+  input[type="text"],
+  input.lotusText {
+    @include textinput;
+    padding-top: .375rem !important;
+  }
+  div[role="search"] {
+    border: none !important;
+  }
+  li.lotusFirst a {
+    outline: none !important;
+  }
+  button[id="lconn_btn_browse_files"] {
+    @include btnprimary;
+  }
+  input[type="submit"] {
+    @include btnprimary;
+    &.lotusBtnDisabled {
+      @include btnprimarydisabled;
+    }
+  }
+  input[value="Cancel"] {
+    @include btnsecondary;
+  }
+  .lotusDialogHeader {
+  	background-color: $background-main !important;
+  	color: $text-01 !important;
+  	h1 {
+      color: $text-01 !important;
+    	font-weight:500!important;
+    	font-size: $title-font-size !important;
+  	}
+  }
+  .lotusDialogClose img {
+  	display:none!important;
+  }
+  .lotusDialogClose {
+  	@include bx--modal-close;
+  }
+  div[role="tablist"] {
+    padding-bottom: calc(.375rem + 3px) !important;
+  }
+  // tab list items styling (a):
+  .dijitTabInner.dijitTabContent,
+  .lconnPickerSourceToCheck .lconnPickerSourceLabel {
+    position: relative;
+    padding: 8px 16px 4px 32px !important;
+    margin: 0 !important;
+    color: $tab-text !important;
+    border-radius: $border-radius-tabs !important;
+    border: 1px solid transparent !important;
+    width: auto !important;
+    .lconnPickerSourceLabelSpan {
+      color: inherit !important;
+    }
+    &:hover {
+      color: $tab-text-hover !important;
+      background-color: $tab-background-hover !important;
+      border-color: $tab-border-hover !important;
+    }
+    &:focus {
+      color: $tab-text-focus !important;
+      background-color: $tab-background-focus !important;
+      border-color: $tab-border-focus !important;
+      outline: none !important;
+    }
+    img {
+      left: .75rem;
+      position: absolute;
+      &[class*="Folder"] {
+        left: .25rem;
+      }
+    }
+  }
+}
+
+//Sharebox Files tab
+body.lotusui30_body > .uploadFileGadgetDiv {
+  button[id="lconn_btn_browse_files"],
+  input[type="submit"] {
+    @include btnprimary;
+  }
+  input[value="Cancel"] {
+    @include btnsecondary;
+  }
+  a[id^="additionalOptions"] {
+    &:focus {
+      outline: none !important;
+    }
+  }
+  input[type="text"] {
+    @include textinput;
+    padding-bottom: 11px !important;  }
+  select {
+    @include select;
+  }
+  textarea {
+    @include textarea;
+  }
+}
+
+div[id^="com_ibm_social_sharebox_controls_TabContainer"] {
+  margin-left: .5rem !important;
+  .dijitTabListContainer-top div[role="tablist"] .dijitTabInner.dijitTabContent.dijitTabChecked .tabLabel:hover {
+    color: $tab-text-hover !important;
+    background-color: $tab-background-hover !important;
+  }
+  .dijitTabInner.dijitTabContent.dijitTabHover {
+    background-color: transparent !important;
+  }
+  .tabLabel {
+    margin-bottom: 0 !important;
+  }
+}

--- a/scss/surveys.scss
+++ b/scss/surveys.scss
@@ -1,0 +1,31 @@
+/*
+	 * © Copyright IBM Corp. 2017, 2018
+	 *
+	 * Licensed under the Apache License, Version 2.0 (the "License");
+	 * you may not use this file except in compliance with the License.
+	 * You may obtain a copy of the License at:
+	 *
+	 * http://www.apache.org/licenses/LICENSE-2.0
+	 *
+	 * Unless required by applicable law or agreed to in writing, software
+	 * distributed under the License is distributed on an "AS IS" BASIS,
+	 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+	 * implied. See the License for the specific language governing
+	 * permissions and limitations under the License.
+*/
+/* SURVEYS STYLE SHEET */
+// Variable and mixin Imports
+@import "prereqs/prereqs";
+// Component Imports
+@import "components/components";
+// App Specific Imports
+@import "apps/communities/appNavigator";
+@import "apps/communities/comments";
+@import "apps/communities/dialogs";
+@import "apps/communities/leftnav";
+@import "apps/communities/metaTags";
+@import "apps/communities/spacing";
+@import "apps/communities/newentry";
+@import "apps/communities/tips";
+// App Specific Imports
+@import "apps/surveys/surveys";

--- a/tmScript.js
+++ b/tmScript.js
@@ -18,6 +18,7 @@
 // @resource     profiles file:///YOURFILEPATHGOESHERE/cnx-custom-theme/css/profiles.css
 // @resource     search file:///YOURFILEPATHGOESHERE/cnx-custom-theme/css/search.css
 // @resource     settings file:///YOURFILEPATHGOESHERE/cnx-custom-theme/css/settings.css
+// @resource     surveys file:///YOURFILEPATHGOESHERE/cnx-custom-theme/css/surveys.css
 // @resource     wikis file:///YOURFILEPATHGOESHERE/cnx-custom-theme/css/wikis.css
 // @match        https://apps.na.collabserv.com/activities/*
 // @match        https://apps.na.collabserv.com/blogs/*


### PR DESCRIPTION
November 2018 visual styling updates for the features below.

### Insert   Image dialog
Update styles for the insert   image dialog that is available when editing a blog, wiki, or forum post.
2236: Update border color for   the image layout options.
2238: Adjust top padding to   reduce spacing above the dialog title.
2240: Update selected border   color and focus style for selected image.
### On-premises Action Center
When Action Center is enabled,   it applies some styles to all of Connections that have an undesirable effect   on our visual style updates. As a result some fixes are being put in to   account for the case that Action Center might be enabled.
2214: Updated Search panel   positioning on the right side and set position from top to be relative to the   height of the navigation bar.
2223: Added more specific selectors to style share box to better work with the search panel updates.
### Community Wiki
1558: Updated position of search icon in top right corner to be consistent with other pages and not   touch the top navigation bar.
### Files
2207: Fixed spacing issue between entries in the left navigation.
2224: Fixed alignment of checkboxes to be vertically centered.
2224: in the updated Files UI, fixed placement of separator bar in toolbar to line up with the right side of the left navigation.
### Homepage classic
2141: Updated min-width for events and meetings notifications on the home page so that the do not extend   beyond the page margins.
### Navigation bar - Share Box -  Styling released
2205: On-premises: Updated the   share dialog that is in the navigation bar.
2179: Update Sametime login   and logout buttons.
### Documentation
2230: Updated support topic to   include a statement on our browser support.