### PR TITLE
Fix Event repeat layout

### DIFF
--- a/css/communities.css
+++ b/css/communities.css
@@ -10481,6 +10481,15 @@ input[type=file]:focus, input[type=file] .dijitTextBoxFocused {
   outline: none;
 }
 
+/* CNXSERV-11141-repeating-event */
+.lotusTable.recWeekdayPicker.dijitInlineTable td {
+  display: table-cell !important;
+}
+
+div.recOptions {
+  background: #FFF !important;
+}
+
 #body .lconnPickerSourceArea .headerSelector .checkbox {
   margin-top: 5px !important;
 }

--- a/scss/apps/communities/_calendarView.scss
+++ b/scss/apps/communities/_calendarView.scss
@@ -39,3 +39,9 @@
     }
   }
 }
+
+/* CNXSERV-11141-repeating-event */
+.lotusTable.recWeekdayPicker.dijitInlineTable td {display: table-cell !important;}
+
+div.recOptions { background: #FFF !important;}
+


### PR DESCRIPTION
When you create a repeating event in a community, the layout of the Event repeat area now shows the day-of-week abbreviations and checkboxes in two horizontally aligned rows, instead of as vertically stacked:

![image](https://media.git.cwp.pnp-hcl.com/user/2077/files/24236c80-05ba-11ec-8e8e-adf71aded9b5)

